### PR TITLE
feat: Allow Generator Inputs to be from File

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ The above command should generate `GREETINGS.md` file with the following content
 # Greetings Felix!
 ```
 
+You can also input variables with a file in `.yaml` format.
+
+`variables.yaml`
+
+```yaml
+name: Felix
+```
+
+```sh
+mason build -t greetings.yaml --vars-file variables.yaml
+```
+
+The above command should generate `GREETINGS.md` file with the following content:
+
+```md
+# Greetings Felix!
+```
+
 ## Usage
 
 ```sh

--- a/example/README.md
+++ b/example/README.md
@@ -11,3 +11,17 @@ mason build -t templates/greetings/greetings.yaml -- --name Joe
 ```md
 # Greetings Joe!
 ```
+
+## Usage with variable file
+
+Rull the following command in the current directory:
+
+```sh
+mason build -t templates/from_variable_file/from_variable_file.yaml --vars-file templates/from_variable_file/variables.yaml
+```
+
+`generated.md` should be created in the current directory with the following contents:
+
+```md
+# Good Afternoon Marcus! This is populated by a yaml file.
+```

--- a/example/templates/from_variable_file/from_variable_file.yaml
+++ b/example/templates/from_variable_file/from_variable_file.yaml
@@ -1,0 +1,8 @@
+name: widget
+description: A Flutter Widget Template
+files:
+  - from: template.md
+    to: generated.md
+vars:
+  - name
+  - greeting

--- a/example/templates/from_variable_file/template.md
+++ b/example/templates/from_variable_file/template.md
@@ -1,0 +1,1 @@
+# {{greeting} {{name}}! This is populated by a yaml file.

--- a/example/templates/from_variable_file/template.md
+++ b/example/templates/from_variable_file/template.md
@@ -1,1 +1,1 @@
-# {{greeting} {{name}}! This is populated by a yaml file.
+# {{greeting}} {{name}}! This is populated by a yaml file.

--- a/example/templates/from_variable_file/variables.yaml
+++ b/example/templates/from_variable_file/variables.yaml
@@ -1,0 +1,2 @@
+name: Marcus
+greeting: Good Afternoon

--- a/lib/src/mason_cli.dart
+++ b/lib/src/mason_cli.dart
@@ -51,10 +51,17 @@ class MasonCli {
       if (options.varsFile != null) {
         final file = File(options.varsFile);
         final content = await file.readAsString();
-        final localVars = checkedYamlDecode(
-            content, (m) => Map.castFrom<dynamic, dynamic, String, String>(m));
-        for (final variable in generator.vars) {
-          vars[variable] = localVars[variable];
+        try {
+          final localVars = checkedYamlDecode(content,
+              (m) => Map.castFrom<dynamic, dynamic, String, String>(m));
+          for (final variable in generator.vars) {
+            vars[variable] = localVars[variable];
+          }
+        } on TypeError catch (_) {
+          throw Exception(
+            'Variable file (${options.varsFile})'
+            ' is not in the format Map<String, String>',
+          );
         }
       } else {
         for (final variable in generator.vars) {

--- a/lib/src/mason_cli.dart
+++ b/lib/src/mason_cli.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 import 'dart:io' as io;
+import 'dart:io';
+import 'package:checked_yaml/checked_yaml.dart';
 import 'package:io/ansi.dart';
 import 'package:io/io.dart';
 import 'package:path/path.dart' as path;
@@ -46,10 +48,20 @@ class MasonCli {
       final generator = await MasonGenerator.fromYaml(options.template);
       final vars = <String, String>{};
 
-      for (final variable in generator.vars) {
-        final index = args.indexOf('--$variable');
-        if (index != -1) {
-          vars.addAll({variable: args[index + 1]});
+      if (options.varsFile != null) {
+        final file = File(options.varsFile);
+        final content = await file.readAsString();
+        final localVars = checkedYamlDecode(
+            content, (m) => Map.castFrom<dynamic, dynamic, String, String>(m));
+        for (final variable in generator.vars) {
+          vars[variable] = localVars[variable];
+        }
+      } else {
+        for (final variable in generator.vars) {
+          final index = args.indexOf('--$variable');
+          if (index != -1) {
+            vars.addAll({variable: args[index + 1]});
+          }
         }
       }
 

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -16,6 +16,7 @@ class Options {
     this.help,
     this.version,
     this.command,
+    this.varsFile,
   });
 
   /// Path to template.yaml
@@ -40,6 +41,14 @@ class Options {
     help: 'Print the current version.',
   )
   final bool version;
+
+  /// Optional path to vars.yaml, which contains
+  ///  the variables to be merged into the template
+  @CliOption(
+    name: 'vars-file',
+    help: 'Variables file path.',
+  )
+  final String varsFile;
 
   /// The results of parsing a series of command line arguments using
   /// [ArgParser.parse()].

--- a/lib/src/options.g.dart
+++ b/lib/src/options.g.dart
@@ -10,13 +10,15 @@ Options _$parseOptionsResult(ArgResults result) => Options(
     template: result['template'] as String,
     help: result['help'] as bool,
     version: result['version'] as bool,
-    command: result.command);
+    command: result.command,
+    varsFile: result['vars-file'] as String);
 
 ArgParser _$populateOptionsParser(ArgParser parser) => parser
   ..addOption('template', abbr: 't', help: 'template yaml path')
   ..addFlag('help',
       abbr: 'h', help: 'Prints usage information.', negatable: false)
-  ..addFlag('version', help: 'Print the current version.', negatable: false);
+  ..addFlag('version', help: 'Print the current version.', negatable: false)
+  ..addOption('vars-file', help: 'Variables file path.');
 
 final _$parserForOptions = _$populateOptionsParser(ArgParser());
 


### PR DESCRIPTION
## Motivation for Change
While using the CLI, it quickly became obvious to me that if you have lots of variables, specifying all of them as args in the command could become tiresome. This change allows you to specify all the variables in a `.yaml` file, then execute the command to generate the new file like normal.

## Changes
- Added `--vars-file` tag to the CLI, which specifies the path to a variables file.
- Added an example (`examples/templates/from_variable_file`) to show how to generate using a variables file.
- Added a section to the README to describe generating using a variables file.