### PR TITLE
feat: MasonGenerator.fromGitPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.0.1-dev.21
+
+- feat: export `MasonGenerator` and relevant objects to allow `mason` to be consumed as a library
+- feat: expose `fromGitPath` on `MasonGenerator`
+
 # 0.0.1-dev.20
 
 - fix: file loop content template variable resolution

--- a/lib/mason.dart
+++ b/lib/mason.dart
@@ -9,3 +9,8 @@
 /// mason --help
 /// ```
 library mason;
+
+export 'src/exception.dart' show MasonException;
+export 'src/generator.dart' show MasonGenerator, DirectoryGeneratorTarget;
+export 'src/logger.dart' show Logger;
+export 'src/mason_yaml.dart' show GitPath;

--- a/lib/src/commands/get.dart
+++ b/lib/src/commands/get.dart
@@ -4,7 +4,6 @@ import 'package:io/io.dart';
 import 'package:path/path.dart' as p;
 
 import '../command.dart';
-import '../git.dart';
 import '../mason_yaml.dart';
 
 /// {@template get_command}
@@ -51,22 +50,7 @@ class GetCommand extends MasonCommand {
       );
     }
     if (brick.git != null && (cache.read(brick.git.url) == null)) {
-      final dirName = brick.git.ref != null
-          ? '${brick.git.url}-${brick.git.ref}'
-          : brick.git.url;
-      final directory = Directory(p.join(cache.rootDir, 'git', dirName));
-      if (directory.existsSync()) {
-        await directory.delete(recursive: true);
-      }
-      await directory.create(recursive: true);
-      await Git.run(['clone', brick.git.url, directory.path]);
-      if (brick.git.ref != null) {
-        await Git.run(
-          ['checkout', brick.git.ref],
-          processWorkingDir: directory.path,
-        );
-      }
-      return cache.write(brick.git.url, directory.path);
+      await cache.downloadRemoteBrick(brick.git);
     }
   }
 }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.0.1-dev.20';
+const packageVersion = '0.0.1-dev.21';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mason
 description: >
   A Dart template generator which helps teams generate files quickly and consistently.
-version: 0.0.1-dev.20
+version: 0.0.1-dev.21
 homepage: https://github.com/felangel/mason
 
 environment:


### PR DESCRIPTION
- feat: export `MasonGenerator` and relevant objects to allow `mason` to be consumed as a library
- feat: expose `fromGitPath` on `MasonGenerator`