### PR TITLE
fix: normalize brick paths to avoid escaping issues (felangel#39)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - uses: dart-lang/setup-dart@v1
 
       - name: Install Dependencies

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,13 +10,9 @@ on:
       - master
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-
+  setup:
+    runs-on: ubuntu-latest
+      
     steps:      
       - uses: actions/checkout@v2.3.4
       - uses: dart-lang/setup-dart@v1
@@ -31,7 +27,23 @@ jobs:
         run: dart analyze --fatal-infos --fatal-warnings .
 
       - name: Ensure Build
-        run: dart test --run-skipped -t pull-request-only
+        run: dart test --run-skipped -t pull-request-only      
+
+  build:
+    needs: setup
+    
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+
+    steps:      
+      - uses: actions/checkout@v2.3.4
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Install Dependencies
+        run: pub get      
 
       - name: Run Tests
         run: dart test -j 1 -x pull-request-only --coverage=coverage && pub run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.packages --report-on=lib

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,9 +11,15 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    
     container:
       image: google/dart:2.12.0
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,12 +16,10 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-    
-    container:
-      image: google/dart:2.12.0
 
     steps:
       - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1
 
       - name: Install Dependencies
         run: pub get

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,8 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
+      - name: Configure Git
+        run: git config core.protectNTFS false
       - uses: actions/checkout@v2.3.4
       - uses: dart-lang/setup-dart@v1
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,24 +26,8 @@ jobs:
       - name: Analyze
         run: dart analyze --fatal-infos --fatal-warnings .
 
-      # - name: Ensure Build
-      #   run: dart test --run-skipped -t pull-request-only
-
-  test:
-    needs: build
-
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: dart-lang/setup-dart@v1
-
-      - name: Install Dependencies
-        run: pub get
+      - name: Ensure Build
+        run: dart test --run-skipped -t pull-request-only
 
       - name: Run Tests
         run: dart test -j 1 -x pull-request-only --coverage=coverage && pub run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.packages --report-on=lib

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,10 +10,10 @@ on:
       - master
 
 jobs:
-  setup:
+  build:
     runs-on: ubuntu-latest
-      
-    steps:      
+
+    steps:
       - uses: actions/checkout@v2.3.4
       - uses: dart-lang/setup-dart@v1
 
@@ -26,24 +26,24 @@ jobs:
       - name: Analyze
         run: dart analyze --fatal-infos --fatal-warnings .
 
-      - name: Ensure Build
-        run: dart test --run-skipped -t pull-request-only      
+      # - name: Ensure Build
+      #   run: dart test --run-skipped -t pull-request-only
 
-  build:
-    needs: setup
-    
+  test:
+    needs: build
+
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
 
-    steps:      
+    steps:
       - uses: actions/checkout@v2.3.4
       - uses: dart-lang/setup-dart@v1
 
       - name: Install Dependencies
-        run: pub get      
+        run: pub get
 
       - name: Run Tests
         run: dart test -j 1 -x pull-request-only --coverage=coverage && pub run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.packages --report-on=lib

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,9 +17,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
 
-    steps:
-      - name: Configure Git
-        run: git config core.protectNTFS false
+    steps:      
       - uses: actions/checkout@v2.3.4
       - uses: dart-lang/setup-dart@v1
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Write your brick template in the `__brick__` directory using [mustache templates
 
 #### File Resolution
 
-It is possible to resolve files based on path input variables using the `[% %]` tag.
+It is possible to resolve files based on path input variables using the `{{% %}}` tag.
 
 For example, given the following `brick.yaml`:
 
@@ -140,7 +140,7 @@ vars:
 
 And the following brick template:
 
-`__brick__/[% url %]`
+`__brick__/{{% url %}}`
 
 Running `mason make app_icon -- --url path/to/icon.png` will generate `icon.png` with the contents of `path/to/icon.png` where the `path/to/icon.png` can be either a local or remote path.
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Write your brick template in the `__brick__` directory using [mustache templates
 
 #### File Resolution
 
-It is possible to resolve files based on path input variables using the `<% %>` tag.
+It is possible to resolve files based on path input variables using the `[% %]` tag.
 
 For example, given the following `brick.yaml`:
 
@@ -140,7 +140,7 @@ vars:
 
 And the following brick template:
 
-`__brick__/<% url %>`
+`__brick__/[% url %]`
 
 Running `mason make app_icon -- --url path/to/icon.png` will generate `icon.png` with the contents of `path/to/icon.png` where the `path/to/icon.png` can be either a local or remote path.
 

--- a/lib/src/bundler.dart
+++ b/lib/src/bundler.dart
@@ -33,11 +33,9 @@ Future<MasonBundle> createBundle(Directory brick) async {
 }
 
 MasonBundledFile _bundleFile(File file) {
-  final filePath = path
-      .split(file.path)
-      .skipWhile((value) => value != BrickYaml.dir)
-      .skip(1)
-      .join('/');
+  final filePath = path.joinAll(
+    path.split(file.path).skipWhile((value) => value != BrickYaml.dir).skip(1),
+  );
   final data = base64.encode(file.readAsBytesSync());
   final fileType =
       _binaryFileTypes.hasMatch(path.basename(file.path)) ? 'binary' : 'text';

--- a/lib/src/commands/get.dart
+++ b/lib/src/commands/get.dart
@@ -44,14 +44,7 @@ class GetCommand extends MasonCommand {
     if (brick.path != null && (cache.read(brick.path!) == null)) {
       return cache.write(
         brick.path!,
-        File(
-          p.normalize(
-            p.join(
-              entryPoint.path,
-              brick.path,
-            ),
-          ),
-        ).absolute.path,
+        File(p.normalize(p.join(entryPoint.path, brick.path))).absolute.path,
       );
     }
     if (brick.git != null && (cache.read(brick.git!.url) == null)) {

--- a/lib/src/commands/get.dart
+++ b/lib/src/commands/get.dart
@@ -44,7 +44,14 @@ class GetCommand extends MasonCommand {
     if (brick.path != null && (cache.read(brick.path) == null)) {
       return cache.write(
         brick.path,
-        File(p.join(entryPoint.path, brick.path)).absolute.path,
+        File(
+          p.normalize(
+            p.join(
+              entryPoint.path,
+              brick.path,
+            ),
+          ),
+        ).absolute.path,
       );
     }
     if (brick.git != null && (cache.read(brick.git.url) == null)) {

--- a/lib/src/commands/new.dart
+++ b/lib/src/commands/new.dart
@@ -37,9 +37,7 @@ class NewCommand extends MasonCommand {
     final name = results.rest.first.snakeCase;
     final description = results['desc'] as String;
     final directory = Directory(p.join(entryPoint.path, 'bricks'));
-    final brickYaml = File(
-      p.join(directory.path, name, BrickYaml.file),
-    );
+    final brickYaml = File(p.join(directory.path, name, BrickYaml.file));
 
     if (brickYaml.existsSync()) {
       logger.err('Existing brick: $name at ${brickYaml.path}');
@@ -52,14 +50,10 @@ class NewCommand extends MasonCommand {
     final bricks = Map.of(masonYaml.bricks)
       ..addAll({
         name: Brick(
-          path:
-              // TODO: Refactor with a safer method.
-              p
-                  .relative(
-                    brickYaml.parent.path,
-                    from: entryPoint.path,
-                  )
-                  .replaceAll(r'\', r'/'),
+          path: p.normalize(p.relative(
+            brickYaml.parent.path,
+            from: entryPoint.path,
+          )),
         )
       });
 

--- a/lib/src/commands/new.dart
+++ b/lib/src/commands/new.dart
@@ -52,10 +52,14 @@ class NewCommand extends MasonCommand {
     final bricks = Map.of(masonYaml.bricks)
       ..addAll({
         name: Brick(
-          path: p.relative(
-            brickYaml.parent.path,
-            from: entryPoint.path,
-          ),
+          path:
+              // TODO: Refactor with a safer method.
+              p
+                  .relative(
+                    brickYaml.parent.path,
+                    from: entryPoint.path,
+                  )
+                  .replaceAll(r'\', r'/'),
         )
       });
 

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -15,7 +15,7 @@ import 'mason_cache.dart';
 import 'mason_yaml.dart';
 import 'render.dart';
 
-final _fileRegExp = RegExp(r'\[%\s?([a-zA-Z]+)\s?%\]');
+final _fileRegExp = RegExp(r'{{%\s?([a-zA-Z]+)\s?%}}');
 final _delimeterRegExp = RegExp(r'{{(.*?)}}');
 final _loopKeyRegExp = RegExp(r'{{#(.*?)}}');
 final _loopValueRegExp = RegExp(r'{{#.*?}}.*?{{{(.*?)}}}.*?{{\/.*?}}');

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -15,7 +15,7 @@ import 'mason_cache.dart';
 import 'mason_yaml.dart';
 import 'render.dart';
 
-final _fileRegExp = RegExp(r'<%\s?([a-zA-Z]+)\s?%>');
+final _fileRegExp = RegExp(r'\[%\s?([a-zA-Z]+)\s?%\]');
 final _delimeterRegExp = RegExp(r'{{(.*?)}}');
 final _loopKeyRegExp = RegExp(r'{{#(.*?)}}');
 final _loopValueRegExp = RegExp(r'{{#.*?}}.*?{{{(.*?)}}}.*?{{\/.*?}}');

--- a/lib/src/mason_cache.dart
+++ b/lib/src/mason_cache.dart
@@ -111,12 +111,10 @@ String _masonCacheDir() {
   } else if (Platform.isWindows) {
     final appData = Platform.environment['APPDATA']!;
     final appDataCacheDir = Directory(p.join(appData, 'Mason', 'Cache'));
-    if (appDataCacheDir.existsSync()) {
-      return appDataCacheDir.path;
-    }
+    if (appDataCacheDir.existsSync()) return appDataCacheDir.path;
     final localAppData = Platform.environment['LOCALAPPDATA']!;
     return p.join(localAppData, 'Mason', 'Cache');
   } else {
-    return '${Platform.environment['HOME']}/.mason-cache';
+    return p.join(Platform.environment['HOME']!, '.mason-cache');
   }
 }

--- a/test/commands/bundle_test.dart
+++ b/test/commands/bundle_test.dart
@@ -33,7 +33,7 @@ void main() {
       final testDir = Directory(
         path.join(Directory.current.path, 'universal'),
       )..createSync(recursive: true);
-      final brickPath = path.normalize('../../../../bricks/greeting');
+      final brickPath = path.join('..', '..', '..', '..', 'bricks', 'greeting');
       Directory.current = testDir.path;
       final result = await commandRunner.run(['bundle', brickPath]);
       expect(result, equals(ExitCode.success.code));
@@ -50,7 +50,7 @@ void main() {
       final testDir = Directory(
         path.join(Directory.current.path, 'dart'),
       )..createSync(recursive: true);
-      final brickPath = path.normalize('../../../../bricks/greeting');
+      final brickPath = path.join('..', '..', '..', '..', 'bricks', 'greeting');
       Directory.current = testDir.path;
       final result = await commandRunner.run(
         ['bundle', brickPath, '-t', 'dart'],
@@ -74,7 +74,7 @@ void main() {
     });
 
     test('exits with code 64 when no brick exists at path', () async {
-      final brickPath = path.normalize('./path/to/brick');
+      final brickPath = path.join('path', 'to', 'brick');
       final result = await commandRunner.run(['bundle', brickPath]);
       expect(result, equals(ExitCode.usage.code));
       verify(

--- a/test/commands/bundle_test.dart
+++ b/test/commands/bundle_test.dart
@@ -33,9 +33,9 @@ void main() {
       final testDir = Directory(
         path.join(Directory.current.path, 'universal'),
       )..createSync(recursive: true);
+      final brickPath = path.canonicalize('../../../../bricks/greeting');
       Directory.current = testDir.path;
-      final result =
-          await commandRunner.run(['bundle', '../../../../bricks/greeting']);
+      final result = await commandRunner.run(['bundle', brickPath]);
       expect(result, equals(ExitCode.success.code));
       final actual = Directory(
         path.join(testFixturesPath(cwd, suffix: '.bundle'), 'universal'),
@@ -50,9 +50,11 @@ void main() {
       final testDir = Directory(
         path.join(Directory.current.path, 'dart'),
       )..createSync(recursive: true);
+      final brickPath = path.canonicalize('../../../../bricks/greeting');
       Directory.current = testDir.path;
-      final result = await commandRunner
-          .run(['bundle', '../../../../bricks/greeting', '-t', 'dart']);
+      final result = await commandRunner.run(
+        ['bundle', brickPath, '-t', 'dart'],
+      );
       expect(result, equals(ExitCode.success.code));
       final actual = Directory(
         path.join(testFixturesPath(cwd, suffix: '.bundle'), 'dart'),
@@ -72,10 +74,11 @@ void main() {
     });
 
     test('exits with code 64 when no brick exists at path', () async {
-      final result = await commandRunner.run(['bundle', './path/to/brick']);
+      final brickPath = path.canonicalize('./path/to/brick');
+      final result = await commandRunner.run(['bundle', brickPath]);
       expect(result, equals(ExitCode.usage.code));
       verify(
-        () => logger.err('could not find brick at ./path/to/brick'),
+        () => logger.err('could not find brick at $brickPath'),
       ).called(1);
     });
   });

--- a/test/commands/bundle_test.dart
+++ b/test/commands/bundle_test.dart
@@ -33,7 +33,7 @@ void main() {
       final testDir = Directory(
         path.join(Directory.current.path, 'universal'),
       )..createSync(recursive: true);
-      final brickPath = path.canonicalize('../../../../bricks/greeting');
+      final brickPath = path.normalize('../../../../bricks/greeting');
       Directory.current = testDir.path;
       final result = await commandRunner.run(['bundle', brickPath]);
       expect(result, equals(ExitCode.success.code));
@@ -50,7 +50,7 @@ void main() {
       final testDir = Directory(
         path.join(Directory.current.path, 'dart'),
       )..createSync(recursive: true);
-      final brickPath = path.canonicalize('../../../../bricks/greeting');
+      final brickPath = path.normalize('../../../../bricks/greeting');
       Directory.current = testDir.path;
       final result = await commandRunner.run(
         ['bundle', brickPath, '-t', 'dart'],
@@ -74,7 +74,7 @@ void main() {
     });
 
     test('exits with code 64 when no brick exists at path', () async {
-      final brickPath = path.canonicalize('./path/to/brick');
+      final brickPath = path.normalize('./path/to/brick');
       final result = await commandRunner.run(['bundle', brickPath]);
       expect(result, equals(ExitCode.usage.code));
       verify(

--- a/test/commands/get_test.dart
+++ b/test/commands/get_test.dart
@@ -37,7 +37,7 @@ void main() {
     path: ../../bricks/todos
   widget:
     git:
-      url: git@github.com:felangel/mason.git
+      url: https://github.com/felangel/mason
       path: bricks/widget
 ''');
     });
@@ -64,38 +64,33 @@ void main() {
 
       expect(File(expectedBrickJsonPath).existsSync(), isTrue);
 
+      final bricksPath = path.join('..', '..', 'bricks');
+
       final appIconPath = path.canonicalize(
-        path.join(Directory.current.path, '..', '..', 'bricks', 'app_icon'),
+        path.join(Directory.current.path, bricksPath, 'app_icon'),
       );
-
       final docPath = path.canonicalize(
-        path.join(
-            Directory.current.path, '..', '..', 'bricks', 'documentation'),
+        path.join(Directory.current.path, bricksPath, 'documentation'),
       );
-
       final greetingPath = path.canonicalize(
-        path.join(Directory.current.path, '..', '..', 'bricks', 'greeting'),
+        path.join(Directory.current.path, bricksPath, 'greeting'),
       );
-
       final todosPath = path.canonicalize(
-        path.join(Directory.current.path, '..', '..', 'bricks', 'todos'),
+        path.join(Directory.current.path, bricksPath, 'todos'),
       );
 
-      final masonUrl = path.join(
-        MasonCache.empty().rootDir,
-        'git',
-        'git@github.com:felangel/mason.git',
-      );
+      final gitUrl = 'https://github.com/felangel/mason';
+      final masonUrl = path.join(MasonCache.empty().rootDir, 'git', gitUrl);
 
       expect(
         File(expectedBrickJsonPath).readAsStringSync(),
         equals(
           '{'
-          '"../../bricks/app_icon":"$appIconPath",'
-          '"../../bricks/documentation":"$docPath",'
-          '"../../bricks/greeting":"$greetingPath",'
-          '"../../bricks/todos":"$todosPath",'
-          '"git@github.com:felangel/mason.git":"$masonUrl"'
+          '"${path.join(bricksPath, 'app_icon')}":"$appIconPath",'
+          '"${path.join(bricksPath, 'documentation')}":"$docPath",'
+          '"${path.join(bricksPath, 'greeting')}":"$greetingPath",'
+          '"${path.join(bricksPath, 'todos')}":"$todosPath",'
+          '"$gitUrl":"$masonUrl"'
           '}',
         ),
       );

--- a/test/commands/get_test.dart
+++ b/test/commands/get_test.dart
@@ -88,9 +88,9 @@ void main() {
           '../../bricks/todos',
         ),
       );
-      final masonUrl = path.canonicalize(
-        '${MasonCache.empty().rootDir}/git/https://github.com/felangel/mason',
-      );
+      final masonUrl =
+          '${MasonCache.empty().rootDir}/git/https://github.com/felangel/mason';
+
       expect(
         File(expectedBrickJsonPath).readAsStringSync(),
         equals(

--- a/test/commands/get_test.dart
+++ b/test/commands/get_test.dart
@@ -67,25 +67,25 @@ void main() {
       final appIconPath = path.canonicalize(
         path.join(
           Directory.current.path,
-          '/../../bricks/app_icon',
+          '../../bricks/app_icon',
         ),
       );
       final docPath = path.canonicalize(
         path.join(
           Directory.current.path,
-          '/../../bricks/documentation',
+          '../../bricks/documentation',
         ),
       );
       final greetingPath = path.canonicalize(
         path.join(
           Directory.current.path,
-          '/../../bricks/greeting',
+          '../../bricks/greeting',
         ),
       );
       final todosPath = path.canonicalize(
         path.join(
           Directory.current.path,
-          '/../../bricks/todos',
+          '../../bricks/todos',
         ),
       );
       final masonUrl =

--- a/test/commands/get_test.dart
+++ b/test/commands/get_test.dart
@@ -88,8 +88,9 @@ void main() {
           '../../bricks/todos',
         ),
       );
-      final masonUrl =
-          '${MasonCache.empty().rootDir}/git/https://github.com/felangel/mason';
+      final masonUrl = path.canonicalize(
+        '${MasonCache.empty().rootDir}/git/https://github.com/felangel/mason',
+      );
       expect(
         File(expectedBrickJsonPath).readAsStringSync(),
         equals(

--- a/test/commands/get_test.dart
+++ b/test/commands/get_test.dart
@@ -65,31 +65,24 @@ void main() {
       expect(File(expectedBrickJsonPath).existsSync(), isTrue);
 
       final appIconPath = path.canonicalize(
-        path.join(
-          Directory.current.path,
-          '../../bricks/app_icon',
-        ),
+        path.join(Directory.current.path, '..', '..', 'bricks', 'app_icon'),
       );
+
       final docPath = path.canonicalize(
         path.join(
-          Directory.current.path,
-          '../../bricks/documentation',
-        ),
+            Directory.current.path, '..', '..', 'bricks', 'documentation'),
       );
+
       final greetingPath = path.canonicalize(
-        path.join(
-          Directory.current.path,
-          '../../bricks/greeting',
-        ),
+        path.join(Directory.current.path, '..', '..', 'bricks', 'greeting'),
       );
+
       final todosPath = path.canonicalize(
-        path.join(
-          Directory.current.path,
-          '../../bricks/todos',
-        ),
+        path.join(Directory.current.path, '..', '..', 'bricks', 'todos'),
       );
-      final masonUrl =
-          '${MasonCache.empty().rootDir}/git/https://github.com/felangel/mason';
+
+      final masonUrl = path.join(MasonCache.empty().rootDir, 'git',
+          'https://github.com/felangel/mason');
 
       expect(
         File(expectedBrickJsonPath).readAsStringSync(),

--- a/test/commands/get_test.dart
+++ b/test/commands/get_test.dart
@@ -70,19 +70,19 @@ void main() {
           '/../../bricks/app_icon',
         ),
       );
-      final docPath = path.normalize(
+      final docPath = path.canonicalize(
         path.join(
           Directory.current.path,
           '/../../bricks/documentation',
         ),
       );
-      final greetingPath = path.normalize(
+      final greetingPath = path.canonicalize(
         path.join(
           Directory.current.path,
           '/../../bricks/greeting',
         ),
       );
-      final todosPath = path.normalize(
+      final todosPath = path.canonicalize(
         path.join(
           Directory.current.path,
           '/../../bricks/todos',

--- a/test/commands/get_test.dart
+++ b/test/commands/get_test.dart
@@ -37,7 +37,7 @@ void main() {
     path: ../../bricks/todos
   widget:
     git:
-      url: https://github.com/felangel/mason
+      url: git@github.com:felangel/mason.git
       path: bricks/widget
 ''');
     });
@@ -81,8 +81,11 @@ void main() {
         path.join(Directory.current.path, '..', '..', 'bricks', 'todos'),
       );
 
-      final masonUrl = path.join(MasonCache.empty().rootDir, 'git',
-          'https://github.com/felangel/mason');
+      final masonUrl = path.join(
+        MasonCache.empty().rootDir,
+        'git',
+        'git@github.com:felangel/mason.git',
+      );
 
       expect(
         File(expectedBrickJsonPath).readAsStringSync(),
@@ -92,7 +95,7 @@ void main() {
           '"../../bricks/documentation":"$docPath",'
           '"../../bricks/greeting":"$greetingPath",'
           '"../../bricks/todos":"$todosPath",'
-          '"https://github.com/felangel/mason":"$masonUrl"'
+          '"git@github.com:felangel/mason.git":"$masonUrl"'
           '}',
         ),
       );

--- a/test/commands/get_test.dart
+++ b/test/commands/get_test.dart
@@ -64,7 +64,7 @@ void main() {
 
       expect(File(expectedBrickJsonPath).existsSync(), isTrue);
 
-      final appIconPath = path.normalize(
+      final appIconPath = path.canonicalize(
         path.join(
           Directory.current.path,
           '/../../bricks/app_icon',

--- a/test/commands/get_test.dart
+++ b/test/commands/get_test.dart
@@ -63,10 +63,43 @@ void main() {
       expect(result, equals(ExitCode.success.code));
 
       expect(File(expectedBrickJsonPath).existsSync(), isTrue);
+
+      final appIconPath = path.normalize(
+        path.join(
+          Directory.current.path,
+          '/../../bricks/app_icon',
+        ),
+      );
+      final docPath = path.normalize(
+        path.join(
+          Directory.current.path,
+          '/../../bricks/documentation',
+        ),
+      );
+      final greetingPath = path.normalize(
+        path.join(
+          Directory.current.path,
+          '/../../bricks/greeting',
+        ),
+      );
+      final todosPath = path.normalize(
+        path.join(
+          Directory.current.path,
+          '/../../bricks/todos',
+        ),
+      );
+      final masonUrl =
+          '${MasonCache.empty().rootDir}/git/https://github.com/felangel/mason';
       expect(
         File(expectedBrickJsonPath).readAsStringSync(),
         equals(
-          '''{"../../bricks/app_icon":"${Directory.current.path}/../../bricks/app_icon","../../bricks/documentation":"${Directory.current.path}/../../bricks/documentation","../../bricks/greeting":"${Directory.current.path}/../../bricks/greeting","../../bricks/todos":"${Directory.current.path}/../../bricks/todos","https://github.com/felangel/mason":"${MasonCache.empty().rootDir}/git/https://github.com/felangel/mason"}''',
+          '{'
+          '"../../bricks/app_icon":"$appIconPath",'
+          '"../../bricks/documentation":"$docPath",'
+          '"../../bricks/greeting":"$greetingPath",'
+          '"../../bricks/todos":"$todosPath",'
+          '"https://github.com/felangel/mason":"$masonUrl"'
+          '}',
         ),
       );
 

--- a/test/helpers/directories_deep_equal.dart
+++ b/test/helpers/directories_deep_equal.dart
@@ -23,9 +23,9 @@ bool directoriesDeepEqual(Directory? a, Directory? b) {
 
     if (path.basename(fileA.path) != path.basename(fileB.path)) return false;
     if (!_equality.equals(fileA.readAsBytesSync(), fileB.readAsBytesSync())) {
-      print(fileA.readAsBytesSync());
+      print(fileA.readAsStringSync());
       print('---');
-      print(fileB.readAsBytesSync());
+      print(fileB.readAsStringSync());
       return false;
     }
   }

--- a/test/helpers/directories_deep_equal.dart
+++ b/test/helpers/directories_deep_equal.dart
@@ -23,6 +23,9 @@ bool directoriesDeepEqual(Directory? a, Directory? b) {
 
     if (path.basename(fileA.path) != path.basename(fileB.path)) return false;
     if (!_equality.equals(fileA.readAsBytesSync(), fileB.readAsBytesSync())) {
+      print(fileA.readAsBytesSync());
+      print('---');
+      print(fileB.readAsBytesSync());
       return false;
     }
   }

--- a/test/helpers/directories_deep_equal.dart
+++ b/test/helpers/directories_deep_equal.dart
@@ -23,9 +23,6 @@ bool directoriesDeepEqual(Directory? a, Directory? b) {
 
     if (path.basename(fileA.path) != path.basename(fileB.path)) return false;
     if (!_equality.equals(fileA.readAsBytesSync(), fileB.readAsBytesSync())) {
-      print(fileA.readAsStringSync());
-      print('---');
-      print(fileB.readAsStringSync());
       return false;
     }
   }


### PR DESCRIPTION
Normalize path according to platform in order to avoid escaping issues (felangel#39)

## Description

- fix: normalize brick location path according to platform and use posix-styled path for brick registering relative path to avoid escaping-related errors (closes #39)
  On Windows, posix separator usage leads to issues.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
