### PR TITLE
fix: improved error handling and error reporting

### DIFF
--- a/lib/src/command.dart
+++ b/lib/src/command.dart
@@ -150,11 +150,10 @@ abstract class MasonCommand extends Command<int> {
     if (_masonYaml != null) return _masonYaml!;
     final masonYamlContent = masonYamlFile.readAsStringSync();
     try {
-      _masonYaml = checkedYamlDecode(
+      return _masonYaml = checkedYamlDecode(
         masonYamlContent,
         (m) => MasonYaml.fromJson(m!),
-      );
-      return _masonYaml!;
+      )!;
     } on ParsedYamlException catch (e) {
       throw MasonYamlParseException(
         'Malformed ${MasonYaml.file} at ${masonYamlFile.path}\n${e.message}',

--- a/lib/src/commands/get.dart
+++ b/lib/src/commands/get.dart
@@ -32,9 +32,11 @@ class GetCommand extends MasonCommand {
     final getDone = logger.progress('getting bricks');
     final force = results['force'] == true;
     if (force) cache.clear();
-    await Future.forEach(masonYaml.bricks.values, _download);
-    await bricksJson.create(recursive: true);
-    await bricksJson.writeAsString(cache.encode);
+    if (masonYaml.bricks.values.isNotEmpty) {
+      await Future.forEach(masonYaml.bricks.values, _download);
+      await bricksJson.create(recursive: true);
+      await bricksJson.writeAsString(cache.encode);
+    }
     getDone();
     return ExitCode.success.code;
   }

--- a/lib/src/commands/make.dart
+++ b/lib/src/commands/make.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'package:args/command_runner.dart';
 import 'package:io/ansi.dart';
 import 'package:io/io.dart';
 import 'package:mason/mason.dart';
@@ -35,7 +36,11 @@ class MakeCommand extends MasonCommand {
   Future<int> run() async {
     // ignore: only_throw_errors
     if (_exception != null) throw _exception!;
-    return ExitCode.success.code;
+    final subcommand = results.rest.isNotEmpty ? results.rest.first : '';
+    throw UsageException(
+      '''Could not find a subcommand named "$subcommand" for "mason make".''',
+      usage,
+    );
   }
 }
 

--- a/lib/src/commands/new.dart
+++ b/lib/src/commands/new.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:args/command_runner.dart';
 import 'package:io/ansi.dart';
 import 'package:io/io.dart';
 import 'package:mason/mason.dart';
@@ -34,6 +35,9 @@ class NewCommand extends MasonCommand {
 
   @override
   Future<int> run() async {
+    if (results.rest.isEmpty) {
+      throw UsageException('Name of the new brick is required.', usage);
+    }
     final name = results.rest.first.snakeCase;
     final description = results['desc'] as String;
     final directory = Directory(p.join(entryPoint.path, 'bricks'));

--- a/lib/src/mason_cache.dart
+++ b/lib/src/mason_cache.dart
@@ -40,9 +40,11 @@ class MasonCache {
   void _fromBricks(File bricksJson) {
     if (!bricksJson.existsSync()) return;
     final content = bricksJson.readAsStringSync();
-    _cache = Map.castFrom<dynamic, dynamic, String, String>(
-      json.decode(content) as Map,
-    );
+    if (content.isNotEmpty) {
+      _cache = Map.castFrom<dynamic, dynamic, String, String>(
+        json.decode(content) as Map,
+      );
+    }
   }
 
   /// Encodes entire cache contents.

--- a/test/commands/make_test.dart
+++ b/test/commands/make_test.dart
@@ -57,6 +57,14 @@ void main() {
       ).called(1);
     });
 
+    test('exits with code 64 when missing subcommand', () async {
+      final result = await commandRunner.run(['make']);
+      expect(result, equals(ExitCode.usage.code));
+      verify(
+        () => logger.err('Missing subcommand for "mason make".'),
+      ).called(1);
+    });
+
     test('exits with code 64 when mason.yaml does not exist', () async {
       File(path.join(Directory.current.path, 'mason.yaml'))
           .deleteSync(recursive: true);

--- a/test/commands/new_test.dart
+++ b/test/commands/new_test.dart
@@ -53,6 +53,13 @@ void main() {
       expect(directoriesDeepEqual(actual, expected), isTrue);
     });
 
+    test('exits with code 64 when name is missing', () async {
+      File(path.join(Directory.current.path, 'mason.yaml'))
+          .writeAsStringSync('bricks:\n');
+      final result = await commandRunner.run(['new']);
+      expect(result, equals(ExitCode.usage.code));
+    });
+
     test('exits with code 64 when brick already exists', () async {
       File(path.join(Directory.current.path, 'mason.yaml'))
           .writeAsStringSync('bricks:\n');

--- a/test/commands/new_test.dart
+++ b/test/commands/new_test.dart
@@ -58,6 +58,7 @@ void main() {
           .writeAsStringSync('bricks:\n');
       final result = await commandRunner.run(['new']);
       expect(result, equals(ExitCode.usage.code));
+      verify(() => logger.err('Name of the new brick is required.')).called(1);
     });
 
     test('exits with code 64 when brick already exists', () async {


### PR DESCRIPTION
- fix: improved error handling and error reporting
  - improve error message when `mason new` is missing a brick name (closes #37)
  - improve error message when `mason make` is missing a subcommand
  - `mason get` handle empty brick list in `mason.yaml`
  - avoid hydrating cache when `bricks.json` is empty.