### PR TITLE
feat: new templates are readily available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ doc/api/
 # Test Related Files
 coverage/
 test/fixtures/.*/
+
+!test/fixtures/*/.mason/

--- a/lib/src/command.dart
+++ b/lib/src/command.dart
@@ -85,6 +85,12 @@ abstract class MasonCommand extends Command<int> {
   /// Gets the `bricks.json` file for the current [entryPoint].
   File get bricksJson => File(p.join(entryPoint.path, '.mason', 'bricks.json'));
 
+  /// Writes current cache to `brick.json`.
+  Future<void> flushCache() async {
+    await bricksJson.create(recursive: true);
+    await bricksJson.writeAsString(cache.encode);
+  }
+
   /// Gets all [BrickYaml] contents for bricks registered in the `mason.yaml`.
   Set<BrickYaml> get bricks {
     if (_bricks != null) return _bricks!;

--- a/lib/src/commands/get.dart
+++ b/lib/src/commands/get.dart
@@ -34,8 +34,7 @@ class GetCommand extends MasonCommand {
     if (force) cache.clear();
     if (masonYaml.bricks.values.isNotEmpty) {
       await Future.forEach(masonYaml.bricks.values, _download);
-      await bricksJson.create(recursive: true);
-      await bricksJson.writeAsString(cache.encode);
+      await flushCache();
     }
     getDone();
     return ExitCode.success.code;

--- a/test/commands/new_test.dart
+++ b/test/commands/new_test.dart
@@ -50,7 +50,10 @@ void main() {
       final expected = Directory(
         path.join(testFixturesPath(cwd, suffix: 'new')),
       );
-      expect(directoriesDeepEqual(actual, expected), isTrue);
+      expect(
+        directoriesDeepEqual(actual, expected, ignore: 'bricks.json'),
+        isTrue,
+      );
     });
 
     test('exits with code 64 when name is missing', () async {
@@ -72,7 +75,10 @@ void main() {
       final expected = Directory(
         path.join(testFixturesPath(cwd, suffix: 'new')),
       );
-      expect(directoriesDeepEqual(actual, expected), isTrue);
+      expect(
+        directoriesDeepEqual(actual, expected, ignore: 'bricks.json'),
+        isTrue,
+      );
 
       final secondResult = await commandRunner.run(['new', 'hello world']);
       expect(secondResult, equals(ExitCode.usage.code));

--- a/test/commands/new_test.dart
+++ b/test/commands/new_test.dart
@@ -51,7 +51,7 @@ void main() {
         path.join(testFixturesPath(cwd, suffix: 'new')),
       );
       expect(
-        directoriesDeepEqual(actual, expected, ignore: 'bricks.json'),
+        directoriesDeepEqual(actual, expected, ignore: ['bricks.json']),
         isTrue,
       );
     });
@@ -76,7 +76,7 @@ void main() {
         path.join(testFixturesPath(cwd, suffix: 'new')),
       );
       expect(
-        directoriesDeepEqual(actual, expected, ignore: 'bricks.json'),
+        directoriesDeepEqual(actual, expected, ignore: ['bricks.json']),
         isTrue,
       );
 

--- a/test/helpers/directories_deep_equal.dart
+++ b/test/helpers/directories_deep_equal.dart
@@ -4,7 +4,7 @@ import 'package:path/path.dart' as path;
 
 const _equality = DeepCollectionEquality();
 
-bool directoriesDeepEqual(Directory? a, Directory? b) {
+bool directoriesDeepEqual(Directory? a, Directory? b, {String? ignore}) {
   if (identical(a, b)) return true;
   if (a == null && b == null) return true;
   if (a == null || b == null) return false;
@@ -22,6 +22,7 @@ bool directoriesDeepEqual(Directory? a, Directory? b) {
     final fileB = File(fileEntityB.path);
 
     if (path.basename(fileA.path) != path.basename(fileB.path)) return false;
+    if (path.basename(fileA.path) == ignore) continue;
     if (!_equality.equals(fileA.readAsBytesSync(), fileB.readAsBytesSync())) {
       return false;
     }

--- a/test/helpers/directories_deep_equal.dart
+++ b/test/helpers/directories_deep_equal.dart
@@ -4,7 +4,11 @@ import 'package:path/path.dart' as path;
 
 const _equality = DeepCollectionEquality();
 
-bool directoriesDeepEqual(Directory? a, Directory? b, {String? ignore}) {
+bool directoriesDeepEqual(
+  Directory? a,
+  Directory? b, {
+  List<String> ignore = const <String>[],
+}) {
   if (identical(a, b)) return true;
   if (a == null && b == null) return true;
   if (a == null || b == null) return false;
@@ -22,7 +26,7 @@ bool directoriesDeepEqual(Directory? a, Directory? b, {String? ignore}) {
     final fileB = File(fileEntityB.path);
 
     if (path.basename(fileA.path) != path.basename(fileB.path)) return false;
-    if (path.basename(fileA.path) == ignore) continue;
+    if (ignore.contains(path.basename(fileA.path))) continue;
     if (!_equality.equals(fileA.readAsBytesSync(), fileB.readAsBytesSync())) {
       return false;
     }


### PR DESCRIPTION
`mason new <template>` automatically installs the template so that it can be used via `mason make <template>` immediately without requiring a `mason get`.