### PR TITLE
chore: v0.0.1-dev.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.0.1-dev.31
+
+- feat: new templates are readily available
+- docs: update README usage section to include `bundle`
+- docs: update file resolution section and include note about unescaped variables
+
 # 0.0.1-dev.30
 
 - fix: improved error handling and error reporting

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.0.1-dev.30';
+const packageVersion = '0.0.1-dev.31';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mason
 description: >
   A Dart template generator which helps teams generate files quickly and consistently.
-version: 0.0.1-dev.30
+version: 0.0.1-dev.31
 homepage: https://github.com/felangel/mason
 
 environment:


### PR DESCRIPTION
# 0.0.1-dev.31

- feat: new templates are readily available
- docs: update README usage section to include `bundle`
- docs: update file resolution section and include note about unescaped variables