### PR TITLE
docs: update mustache manual link

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ vars:
 
 ### Brick Template
 
-Write your brick template in the `__brick__` directory using [mustache templates](https://mustache.github.io/). See the [mustache manual](https://mustache.github.com/mustache.5.html) for detailed usage information.
+Write your brick template in the `__brick__` directory using [mustache templates](https://mustache.github.io/). See the [mustache manual](https://mustache.github.io/mustache.5.html) for detailed usage information.
 
 `__brick__/example.md`
 


### PR DESCRIPTION
Mustache changed the `.com` link to `.io` for the mustache5 manual. Just updated the link. 👍