### PR TITLE
chore: v0.0.1-dev.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.0.1-dev.33
+
+- feat: mason install command for global brick templates
+- docs: update mustache manual link
+- docs: update mason.yaml from init to use https for git
+
 # 0.0.1-dev.32
 
 - feat!: windows compatibility fixes

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.0.1-dev.32';
+const packageVersion = '0.0.1-dev.33';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mason
 description: >
   A Dart template generator which helps teams generate files quickly and consistently.
-version: 0.0.1-dev.32
+version: 0.0.1-dev.33
 homepage: https://github.com/felangel/mason
 
 environment:


### PR DESCRIPTION
- feat: mason install command for global brick templates
- docs: update mustache manual link
- docs: update mason.yaml from init to use https for git