### PR TITLE
chore: v0.0.1-dev.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.0.1-dev.34
+
+- fix: local mason get installation location for remote bricks
+- fix!: always attempt to fetch latest remote brick
+  - `mason get` no longer supports `--force` since it is handled automatically
+
 # 0.0.1-dev.33
 
 - feat: mason install command for global brick templates

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.0.1-dev.33';
+const packageVersion = '0.0.1-dev.34';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mason
 description: >
   A Dart template generator which helps teams generate files quickly and consistently.
-version: 0.0.1-dev.33
+version: 0.0.1-dev.34
 homepage: https://github.com/felangel/mason
 
 environment:


### PR DESCRIPTION
- fix: local mason get installation location for remote bricks
- fix!: always attempt to fetch latest remote brick
  - `mason get` no longer supports `--force` since it is handled automatically