### PR TITLE
chore: v0.0.1-dev.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.1-dev.35
+
+- fix: adjust `mason cache clear --force` target directory to avoid deleting local files
+
 # 0.0.1-dev.34
 
 - fix: local mason get installation location for remote bricks

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.0.1-dev.34';
+const packageVersion = '0.0.1-dev.35';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mason
 description: >
   A Dart template generator which helps teams generate files quickly and consistently.
-version: 0.0.1-dev.34
+version: 0.0.1-dev.35
 homepage: https://github.com/felangel/mason
 
 environment:


### PR DESCRIPTION
- fix: adjust `mason cache clear --force` target directory to avoid deleting local files