### PR TITLE
feat!: v0.0.1-dev.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.0.1-dev.38
+
+- feat!: remove `--force` from `mason cache clear`
+  - `mason cache clear` will remove all local bricks so `--force` is not necessary
+- fix: `mason cache clear` behavior to always clear local and global brick caches
+- fix: local and global brick installation conflicts
+- fix: `mason list` duplicate bricks
+- refactor: `MasonCache` to `BricksJson`
+  - simplification of internal APIs and cache implementation
+
 # 0.0.1-dev.37
 
 - feat: add `mason list` command

--- a/lib/mason.dart
+++ b/lib/mason.dart
@@ -2,11 +2,11 @@
 /// generate files quickly and consistently.
 ///
 /// ```sh
-/// # activate mason
-/// pub global activate mason
+/// # Activate mason
+/// $ dart pub global activate mason
 ///
-/// # see usage
-/// mason --help
+/// # See usage
+/// $ mason --help
 /// ```
 library mason;
 

--- a/lib/src/brick_yaml.dart
+++ b/lib/src/brick_yaml.dart
@@ -48,4 +48,13 @@ class BrickYaml {
   BrickYaml copyWith({String? path}) {
     return BrickYaml(name, description, vars: vars, path: path ?? this.path);
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is BrickYaml && other.name == name;
+  }
+
+  @override
+  int get hashCode => name.hashCode;
 }

--- a/lib/src/bricks_json.dart
+++ b/lib/src/bricks_json.dart
@@ -44,15 +44,11 @@ class BricksJson {
   late File _bricksJsonFile;
 
   /// Removes all key/value pairs from the cache.
-  /// If [force] is true, all bricks will be removed
-  /// from disk in addition to the in-memory cache.
-  void clear({bool force = false}) {
+  void clear() {
     _cache.clear();
-    if (force) {
-      try {
-        _bricksJsonFile.deleteSync();
-      } catch (_) {}
-    }
+    try {
+      _bricksJsonFile.deleteSync();
+    } catch (_) {}
   }
 
   /// Populates cache based on `.mason/bricks.json`.

--- a/lib/src/command.dart
+++ b/lib/src/command.dart
@@ -191,15 +191,10 @@ abstract class MasonCommand extends Command<int> {
   /// Returns `null` if the brick is not cached.
   String? _cacheDirectory(Brick brick) {
     if (localBricksJson != null) {
-      final key = localBricksJson!.getKey(brick);
-      if (key != null) {
-        final value = localBricksJson!.read(key);
-        if (value != null) return value;
-      }
+      final value = localBricksJson!.getValue(brick);
+      if (value != null) return value;
     }
-    final key = globalBricksJson.getKey(brick);
-    if (key == null) return null;
-    return globalBricksJson.read(key);
+    return globalBricksJson.getValue(brick);
   }
 
   /// Gets all [BrickYaml] instances for the provided [masonYaml].

--- a/lib/src/command.dart
+++ b/lib/src/command.dart
@@ -191,10 +191,10 @@ abstract class MasonCommand extends Command<int> {
   /// Returns `null` if the brick is not cached.
   String? _cacheDirectory(Brick brick) {
     if (localBricksJson != null) {
-      final value = localBricksJson!.getValue(brick);
-      if (value != null) return value;
+      final path = localBricksJson!.getPath(brick);
+      if (path != null) return path;
     }
-    return globalBricksJson.getValue(brick);
+    return globalBricksJson.getPath(brick);
   }
 
   /// Gets all [BrickYaml] instances for the provided [masonYaml].

--- a/lib/src/command.dart
+++ b/lib/src/command.dart
@@ -6,9 +6,9 @@ import 'package:checked_yaml/checked_yaml.dart';
 import 'package:path/path.dart' as p;
 
 import 'brick_yaml.dart';
+import 'bricks_json.dart';
 import 'exception.dart';
 import 'logger.dart';
-import 'mason_cache.dart';
 import 'mason_yaml.dart';
 
 /// {@template brick_not_found_exception}
@@ -34,7 +34,10 @@ class MasonYamlNameMismatch extends MasonException {
 /// {@endtemplate}
 class MasonYamlNotFoundException extends MasonException {
   /// {@macro mason_yaml_not_found_exception}
-  const MasonYamlNotFoundException(String message) : super(message);
+  const MasonYamlNotFoundException()
+      : super(
+          'Cannot find ${MasonYaml.file}.\nDid you forget to run mason init?',
+        );
 }
 
 /// {@template mason_yaml_parse_exception}
@@ -63,12 +66,18 @@ abstract class MasonCommand extends Command<int> {
   /// [ArgResults] for the current command.
   ArgResults get results => argResults!;
 
-  /// [MasonCache] which contains all local brick templates.
-  MasonCache get cache => _cache;
+  /// [BricksJson] which contains all local bricks.
+  BricksJson? get localBricksJson => _localBricksJson;
 
-  late final MasonCache _cache = MasonCache(directory: _cacheEntryPoint);
+  /// [BricksJson] which contains all global bricks.
+  BricksJson get globalBricksJson => _globalBricksJson;
 
-  Directory? get _cacheEntryPoint {
+  late final BricksJson _globalBricksJson = BricksJson.global();
+
+  late final BricksJson? _localBricksJson =
+      __entryPoint != null ? BricksJson(directory: __entryPoint!) : null;
+
+  Directory? get __entryPoint {
     try {
       return entryPoint;
     } catch (_) {}
@@ -79,10 +88,9 @@ abstract class MasonCommand extends Command<int> {
   Directory get entryPoint {
     if (_entryPoint != null) return _entryPoint!;
     final nearestMasonYaml = MasonYaml.findNearest(cwd);
-    if (nearestMasonYaml == null) {
-      throw const MasonYamlNotFoundException(
-        'Could not find ${MasonYaml.file}.\nDid you forget to run mason init?',
-      );
+    if (nearestMasonYaml == null ||
+        nearestMasonYaml.parent.path == BricksJson.globalDir.path) {
+      throw const MasonYamlNotFoundException();
     }
     return _entryPoint = nearestMasonYaml.parent;
   }
@@ -96,7 +104,7 @@ abstract class MasonCommand extends Command<int> {
     return _bricks = {
       if (masonInitialized) ..._getBricks(masonYaml),
       ..._getBricks(
-        _getMasonYaml(_getMasonYamlFile(MasonCache.globalDir.path)),
+        _getMasonYaml(_getMasonYamlFile(BricksJson.globalDir.path)),
       ),
     };
   }
@@ -117,11 +125,7 @@ abstract class MasonCommand extends Command<int> {
   File get masonYamlFile {
     if (_masonYamlFile != null) return _masonYamlFile!;
     final file = File(p.join(entryPoint.path, MasonYaml.file));
-    if (!file.existsSync()) {
-      throw const MasonYamlNotFoundException(
-        'Cannot find ${MasonYaml.file}.\nDid you forget to run mason init?',
-      );
-    }
+    if (!file.existsSync()) throw const MasonYamlNotFoundException();
     return _masonYamlFile = file;
   }
 
@@ -130,7 +134,7 @@ abstract class MasonCommand extends Command<int> {
   /// Gets the global `mason.yaml` file.
   File get globalMasonYamlFile {
     if (_globalMasonYamlFile != null) return _globalMasonYamlFile!;
-    return _globalMasonYamlFile = _getMasonYamlFile(MasonCache.globalDir.path);
+    return _globalMasonYamlFile = _getMasonYamlFile(BricksJson.globalDir.path);
   }
 
   File? _globalMasonYamlFile;
@@ -186,9 +190,16 @@ abstract class MasonCommand extends Command<int> {
   /// The path to the cached brick directory if it exists.
   /// Returns `null` if the brick is not cached.
   String? _cacheDirectory(Brick brick) {
-    final key = cache.getKey(brick);
+    if (localBricksJson != null) {
+      final key = localBricksJson!.getKey(brick);
+      if (key != null) {
+        final value = localBricksJson!.read(key);
+        if (value != null) return value;
+      }
+    }
+    final key = globalBricksJson.getKey(brick);
     if (key == null) return null;
-    return cache.read(key);
+    return globalBricksJson.read(key);
   }
 
   /// Gets all [BrickYaml] instances for the provided [masonYaml].

--- a/lib/src/commands/cache.dart
+++ b/lib/src/commands/cache.dart
@@ -21,18 +21,11 @@ class CacheCommand extends MasonCommand {
 }
 
 /// {@template cache_command}
-/// `mason cache clear` command which wipes the local mason cache.
+/// `mason cache clear` command which clears all local bricks.
 /// {@endtemplate}
 class ClearCacheCommand extends MasonCommand {
   /// {@macro cache_command}
-  ClearCacheCommand({Logger? logger}) : super(logger: logger) {
-    argParser.addFlag(
-      'force',
-      abbr: 'f',
-      defaultsTo: false,
-      help: 'removes all bricks from disk.',
-    );
-  }
+  ClearCacheCommand({Logger? logger}) : super(logger: logger);
 
   @override
   final String description = 'Clears the mason cache.';
@@ -42,21 +35,12 @@ class ClearCacheCommand extends MasonCommand {
 
   @override
   Future<int> run() async {
-    final force = results['force'] == true;
-    if (force) {
-      logger.warn(
-        'using --force\nI sure hope you know what you are doing.',
-      );
-    }
     final clearDone = logger.progress('clearing cache');
-    globalBricksJson.clear();
-    localBricksJson?.clear();
 
-    if (force) {
-      try {
-        BricksJson.rootDir.deleteSync(recursive: true);
-      } catch (_) {}
-    }
+    localBricksJson?.clear();
+    try {
+      BricksJson.rootDir.deleteSync(recursive: true);
+    } catch (_) {}
 
     clearDone();
     return ExitCode.success.code;

--- a/lib/src/commands/cache.dart
+++ b/lib/src/commands/cache.dart
@@ -26,21 +26,12 @@ class CacheCommand extends MasonCommand {
 class ClearCacheCommand extends MasonCommand {
   /// {@macro cache_command}
   ClearCacheCommand({Logger? logger}) : super(logger: logger) {
-    argParser
-      ..addFlag(
-        'force',
-        abbr: 'f',
-        defaultsTo: false,
-        help: 'removes all local bricks from disk and clears '
-            'the in-memory cache.',
-      )
-      ..addFlag(
-        'global',
-        abbr: 'g',
-        defaultsTo: false,
-        help: 'removes all global bricks from disk and clears '
-            'the in-memory cache.',
-      );
+    argParser.addFlag(
+      'force',
+      abbr: 'f',
+      defaultsTo: false,
+      help: 'removes all bricks from disk.',
+    );
   }
 
   @override
@@ -57,9 +48,9 @@ class ClearCacheCommand extends MasonCommand {
         'using --force\nI sure hope you know what you are doing.',
       );
     }
-    final isGlobal = results['global'] == true;
     final clearDone = logger.progress('clearing cache');
-    isGlobal ? globalBricksJson.clear() : localBricksJson?.clear();
+    globalBricksJson.clear();
+    localBricksJson?.clear();
 
     if (force) {
       try {

--- a/lib/src/commands/cache.dart
+++ b/lib/src/commands/cache.dart
@@ -59,11 +59,9 @@ class ClearCacheCommand extends MasonCommand {
     }
     final isGlobal = results['global'] == true;
     final clearDone = logger.progress('clearing cache');
-    isGlobal
-        ? globalBricksJson.clear(force: force)
-        : localBricksJson?.clear(force: force);
+    isGlobal ? globalBricksJson.clear() : localBricksJson?.clear();
 
-    if (isGlobal && force) {
+    if (force) {
       try {
         BricksJson.rootDir.deleteSync(recursive: true);
       } catch (_) {}

--- a/lib/src/commands/get.dart
+++ b/lib/src/commands/get.dart
@@ -18,10 +18,12 @@ class GetCommand extends MasonCommand {
 
   @override
   Future<int> run() async {
+    final bricksJson = localBricksJson;
+    if (bricksJson == null) throw const MasonYamlNotFoundException();
     final getDone = logger.progress('getting bricks');
     if (masonYaml.bricks.values.isNotEmpty) {
-      await Future.forEach(masonYaml.bricks.values, cache.writeBrick);
-      await cache.flush();
+      await Future.forEach(masonYaml.bricks.values, bricksJson.writeBrick);
+      await bricksJson.flush();
     }
     getDone();
     return ExitCode.success.code;

--- a/lib/src/commands/get.dart
+++ b/lib/src/commands/get.dart
@@ -22,7 +22,7 @@ class GetCommand extends MasonCommand {
     if (bricksJson == null) throw const MasonYamlNotFoundException();
     final getDone = logger.progress('getting bricks');
     if (masonYaml.bricks.values.isNotEmpty) {
-      await Future.forEach(masonYaml.bricks.values, bricksJson.writeBrick);
+      await Future.forEach(masonYaml.bricks.values, bricksJson.add);
       await bricksJson.flush();
     }
     getDone();

--- a/lib/src/commands/install.dart
+++ b/lib/src/commands/install.dart
@@ -61,7 +61,7 @@ class InstallCommand extends MasonCommand {
         throw UsageException('brick not found at path $location', usage);
       }
       brick = Brick(path: file.parent.path);
-      await bricksJson.writeBrick(brick);
+      await bricksJson.add(brick);
     } else {
       final gitPath = GitPath(
         location,
@@ -70,7 +70,7 @@ class InstallCommand extends MasonCommand {
       );
       brick = Brick(git: gitPath);
       try {
-        final directory = await bricksJson.writeBrick(brick);
+        final directory = await bricksJson.add(brick);
         file = File(p.join(directory, gitPath.path, BrickYaml.file));
       } catch (_) {
         throw UsageException('brick not found at url $location', usage);

--- a/lib/src/commands/install.dart
+++ b/lib/src/commands/install.dart
@@ -47,7 +47,9 @@ class InstallCommand extends MasonCommand {
     if (results.rest.isEmpty) {
       throw UsageException('path to the brick is required.', usage);
     }
+
     final location = results.rest.first;
+    final bricksJson = globalBricksJson;
     final downloadDone = logger.progress('Downloading brick at $location');
 
     late final Brick brick;
@@ -59,7 +61,7 @@ class InstallCommand extends MasonCommand {
         throw UsageException('brick not found at path $location', usage);
       }
       brick = Brick(path: file.parent.path);
-      await cache.writeBrick(brick);
+      await bricksJson.writeBrick(brick);
     } else {
       final gitPath = GitPath(
         location,
@@ -68,7 +70,7 @@ class InstallCommand extends MasonCommand {
       );
       brick = Brick(git: gitPath);
       try {
-        final directory = await cache.writeBrick(brick);
+        final directory = await bricksJson.writeBrick(brick);
         file = File(p.join(directory, gitPath.path, BrickYaml.file));
       } catch (_) {
         throw UsageException('brick not found at url $location', usage);
@@ -89,7 +91,7 @@ class InstallCommand extends MasonCommand {
         Yaml.encode(MasonYaml(bricks).toJson()),
       );
     }
-    await cache.flush();
+    await bricksJson.flush();
     installDone();
     return ExitCode.success.code;
   }

--- a/lib/src/commands/new.dart
+++ b/lib/src/commands/new.dart
@@ -66,7 +66,7 @@ class NewCommand extends MasonCommand {
       if (!masonYaml.bricks.containsKey(name))
         masonYamlFile.writeAsString(Yaml.encode(MasonYaml(bricks).toJson())),
     ]);
-    await bricksJson.writeBrick(newBrick);
+    await bricksJson.add(newBrick);
     await bricksJson.flush();
 
     done('Created new brick: $name');

--- a/lib/src/commands/new.dart
+++ b/lib/src/commands/new.dart
@@ -38,6 +38,8 @@ class NewCommand extends MasonCommand {
     if (results.rest.isEmpty) {
       throw UsageException('Name of the new brick is required.', usage);
     }
+    final bricksJson = localBricksJson;
+    if (bricksJson == null) throw const MasonYamlNotFoundException();
     final name = results.rest.first.snakeCase;
     final description = results['desc'] as String;
     final directory = Directory(p.join(entryPoint.path, 'bricks'));
@@ -64,8 +66,8 @@ class NewCommand extends MasonCommand {
       if (!masonYaml.bricks.containsKey(name))
         masonYamlFile.writeAsString(Yaml.encode(MasonYaml(bricks).toJson())),
     ]);
-    await cache.writeBrick(newBrick);
-    await cache.flush();
+    await bricksJson.writeBrick(newBrick);
+    await bricksJson.flush();
 
     done('Created new brick: $name');
     logger

--- a/lib/src/commands/uninstall.dart
+++ b/lib/src/commands/uninstall.dart
@@ -28,6 +28,7 @@ class UninstallCommand extends MasonCommand {
       throw UsageException('name of the brick is required.', usage);
     }
 
+    final bricksJson = globalBricksJson;
     final brickName = results.rest.first;
     final brick = globalMasonYaml.bricks[brickName];
     if (brick == null) {
@@ -35,8 +36,8 @@ class UninstallCommand extends MasonCommand {
     }
 
     final uninstallDone = logger.progress('Uninstalling $brickName');
-    final cacheKey = cache.getKey(brick);
-    if (cacheKey != null) cache.remove(cacheKey);
+    final cacheKey = bricksJson.getKey(brick);
+    if (cacheKey != null) bricksJson.remove(cacheKey);
 
     final bricks = Map.of(globalMasonYaml.bricks)
       ..removeWhere((key, value) => key == brickName);
@@ -44,7 +45,7 @@ class UninstallCommand extends MasonCommand {
       Yaml.encode(MasonYaml(bricks).toJson()),
     );
 
-    await cache.flush();
+    await bricksJson.flush();
     uninstallDone();
     return ExitCode.success.code;
   }

--- a/lib/src/commands/uninstall.dart
+++ b/lib/src/commands/uninstall.dart
@@ -36,9 +36,7 @@ class UninstallCommand extends MasonCommand {
     }
 
     final uninstallDone = logger.progress('Uninstalling $brickName');
-    final cacheKey = bricksJson.getKey(brick);
-    if (cacheKey != null) bricksJson.remove(cacheKey);
-
+    bricksJson.remove(brick);
     final bricks = Map.of(globalMasonYaml.bricks)
       ..removeWhere((key, value) => key == brickName);
     globalMasonYamlFile.writeAsStringSync(

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -9,9 +9,9 @@ import 'package:mason/mason.dart';
 import 'package:path/path.dart' as p;
 
 import 'brick_yaml.dart';
+import 'bricks_json.dart';
 import 'logger.dart';
 import 'mason_bundle.dart';
-import 'mason_cache.dart';
 import 'mason_yaml.dart';
 import 'render.dart';
 
@@ -93,8 +93,7 @@ class MasonGenerator extends Generator {
   /// Factory which creates a [MasonGenerator] based on
   /// a [GitPath] for a remote [BrickYaml] file.
   static Future<MasonGenerator> fromGitPath(GitPath gitPath) async {
-    final cache = MasonCache();
-    final directory = await cache.writeBrick(Brick(git: gitPath));
+    final directory = await BricksJson.temp().writeBrick(Brick(git: gitPath));
     final file = File(p.join(directory, gitPath.path, BrickYaml.file));
     final brickYaml = checkedYamlDecode(
       file.readAsStringSync(),

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -93,7 +93,7 @@ class MasonGenerator extends Generator {
   /// Factory which creates a [MasonGenerator] based on
   /// a [GitPath] for a remote [BrickYaml] file.
   static Future<MasonGenerator> fromGitPath(GitPath gitPath) async {
-    final directory = await BricksJson.temp().writeBrick(Brick(git: gitPath));
+    final directory = await BricksJson.temp().add(Brick(git: gitPath));
     final file = File(p.join(directory, gitPath.path, BrickYaml.file));
     final brickYaml = checkedYamlDecode(
       file.readAsStringSync(),

--- a/lib/src/mason_yaml.dart
+++ b/lib/src/mason_yaml.dart
@@ -39,9 +39,7 @@ class MasonYaml {
     var dir = cwd;
     while (prev?.path != dir.path) {
       final masonConfig = File(p.join(dir.path, 'mason.yaml'));
-      if (masonConfig.existsSync()) {
-        return masonConfig;
-      }
+      if (masonConfig.existsSync()) return masonConfig;
       prev = dir;
       dir = dir.parent;
     }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.0.1-dev.37';
+const packageVersion = '0.0.1-dev.38';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mason
 description: >
   A Dart template generator which helps teams generate files quickly and consistently.
-version: 0.0.1-dev.37
+version: 0.0.1-dev.38
 homepage: https://github.com/felangel/mason
 
 environment:

--- a/test/commands/cache_test.dart
+++ b/test/commands/cache_test.dart
@@ -35,7 +35,7 @@ void main() {
       Directory.current = cwd;
     });
 
-    test('clear removes .mason/brick.json', () async {
+    test('clear does not remove .mason/brick.json', () async {
       final expectedBrickJsonPath = path.join(
         Directory.current.path,
         '.mason',
@@ -48,7 +48,7 @@ void main() {
 
       final cacheClearResult = await commandRunner.run(['cache', 'clear']);
       expect(cacheClearResult, equals(ExitCode.success.code));
-      expect(File(expectedBrickJsonPath).existsSync(), isFalse);
+      expect(File(expectedBrickJsonPath).existsSync(), isTrue);
     });
 
     test('clear --force removes .mason/brick.json and warns user', () async {

--- a/test/commands/cache_test.dart
+++ b/test/commands/cache_test.dart
@@ -52,7 +52,7 @@ void main() {
       expect(File(expectedBrickJsonPath).existsSync(), isFalse);
     });
 
-    test('clear -g removes global .mason/bricks.json', () async {
+    test('clear removes global .mason/bricks.json', () async {
       final expectedBrickJsonFile = File(
         path.join(
           BricksJson.globalDir.path,
@@ -67,9 +67,7 @@ void main() {
 
       expect(expectedBrickJsonFile.existsSync(), isTrue);
 
-      final result = await commandRunner.run(
-        ['cache', 'clear', '-g'],
-      );
+      final result = await commandRunner.run(['cache', 'clear']);
       expect(result, equals(ExitCode.success.code));
       expect(expectedBrickJsonFile.existsSync(), isFalse);
     });

--- a/test/commands/cache_test.dart
+++ b/test/commands/cache_test.dart
@@ -72,7 +72,7 @@ void main() {
       expect(expectedBrickJsonFile.existsSync(), isFalse);
     });
 
-    test('clear --force removes .mason/bricks.json and warns user', () async {
+    test('clear removes .mason/bricks.json', () async {
       final expectedBrickJsonPath = path.join(
         Directory.current.path,
         '.mason',
@@ -87,9 +87,7 @@ void main() {
       expect(File(expectedBrickJsonPath).existsSync(), isTrue);
       expect(BricksJson.globalDir.existsSync(), isTrue);
 
-      final cacheClearResult = await commandRunner.run(
-        ['cache', 'clear', '--force'],
-      );
+      final cacheClearResult = await commandRunner.run(['cache', 'clear']);
       expect(cacheClearResult, equals(ExitCode.success.code));
       expect(File(expectedBrickJsonPath).existsSync(), isFalse);
       expect(
@@ -97,11 +95,6 @@ void main() {
         isTrue,
       );
       expect(BricksJson.globalDir.existsSync(), isFalse);
-      verify(
-        () => logger.warn(
-          'using --force\nI sure hope you know what you are doing.',
-        ),
-      ).called(1);
     });
   });
 }

--- a/test/commands/cache_test.dart
+++ b/test/commands/cache_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:io/io.dart';
 import 'package:mason/mason.dart';
+import 'package:mason/src/bricks_json.dart';
 import 'package:mason/src/command_runner.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as path;
@@ -35,7 +36,7 @@ void main() {
       Directory.current = cwd;
     });
 
-    test('clear does not remove .mason/brick.json', () async {
+    test('clear removes local .mason/bricks.json', () async {
       final expectedBrickJsonPath = path.join(
         Directory.current.path,
         '.mason',
@@ -48,19 +49,45 @@ void main() {
 
       final cacheClearResult = await commandRunner.run(['cache', 'clear']);
       expect(cacheClearResult, equals(ExitCode.success.code));
-      expect(File(expectedBrickJsonPath).existsSync(), isTrue);
+      expect(File(expectedBrickJsonPath).existsSync(), isFalse);
     });
 
-    test('clear --force removes .mason/brick.json and warns user', () async {
+    test('clear -g removes global .mason/bricks.json', () async {
+      final expectedBrickJsonFile = File(
+        path.join(
+          BricksJson.globalDir.path,
+          '.mason',
+          'bricks.json',
+        ),
+      );
+
+      if (!expectedBrickJsonFile.existsSync()) {
+        expectedBrickJsonFile.createSync(recursive: true);
+      }
+
+      expect(expectedBrickJsonFile.existsSync(), isTrue);
+
+      final result = await commandRunner.run(
+        ['cache', 'clear', '-g'],
+      );
+      expect(result, equals(ExitCode.success.code));
+      expect(expectedBrickJsonFile.existsSync(), isFalse);
+    });
+
+    test('clear --force removes .mason/bricks.json and warns user', () async {
       final expectedBrickJsonPath = path.join(
         Directory.current.path,
         '.mason',
         'bricks.json',
       );
+      if (!BricksJson.globalDir.existsSync()) {
+        BricksJson.globalDir.createSync(recursive: true);
+      }
 
       final getResult = await commandRunner.run(['get']);
       expect(getResult, equals(ExitCode.success.code));
       expect(File(expectedBrickJsonPath).existsSync(), isTrue);
+      expect(BricksJson.globalDir.existsSync(), isTrue);
 
       final cacheClearResult = await commandRunner.run(
         ['cache', 'clear', '--force'],
@@ -71,6 +98,7 @@ void main() {
         File(path.join(Directory.current.path, 'mason.yaml')).existsSync(),
         isTrue,
       );
+      expect(BricksJson.globalDir.existsSync(), isFalse);
       verify(
         () => logger.warn(
           'using --force\nI sure hope you know what you are doing.',

--- a/test/commands/get_test.dart
+++ b/test/commands/get_test.dart
@@ -3,8 +3,9 @@ import 'dart:io';
 
 import 'package:io/io.dart';
 import 'package:mason/mason.dart';
+import 'package:mason/src/command.dart';
 import 'package:mason/src/command_runner.dart';
-import 'package:mason/src/mason_cache.dart';
+import 'package:mason/src/bricks_json.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
@@ -81,7 +82,7 @@ void main() {
       final widgetPath =
           '''widget_536b4405bffd371ab46f0948d0a5b9a2ac2cddb270ebc3d6f684217f7741422f''';
       final masonUrl = path.join(
-        MasonCache.rootDir.path,
+        BricksJson.rootDir.path,
         'git',
         '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
       );
@@ -143,9 +144,7 @@ void main() {
       final result = await commandRunner.run(['get']);
       expect(result, equals(ExitCode.usage.code));
       verify(
-        () => logger.err(
-          'Could not find mason.yaml.\nDid you forget to run mason init?',
-        ),
+        () => logger.err(const MasonYamlNotFoundException().message),
       ).called(1);
     });
   });

--- a/test/commands/list_test.dart
+++ b/test/commands/list_test.dart
@@ -4,7 +4,7 @@ import 'package:io/ansi.dart';
 import 'package:io/io.dart';
 import 'package:mason/mason.dart';
 import 'package:mason/src/command_runner.dart';
-import 'package:mason/src/mason_cache.dart';
+import 'package:mason/src/bricks_json.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -25,7 +25,7 @@ void main() {
       commandRunner = MasonCommandRunner(logger: logger);
       when(() => logger.progress(any())).thenReturn(([String? _]) {});
       setUpTestingEnvironment(cwd, suffix: '.list');
-      MasonCache().clear(force: true);
+      BricksJson.global().clear(force: true);
     });
 
     tearDown(() {
@@ -38,7 +38,7 @@ void main() {
       verifyNever(() => logger.info(any()));
     });
 
-    test('ls is available as an alis', () async {
+    test('ls is available as an alias', () async {
       final result = await commandRunner.run(['ls']);
       expect(result, equals(ExitCode.success.code));
       verifyNever(() => logger.info(any()));
@@ -65,7 +65,7 @@ void main() {
       );
       await expectLater(
         MasonCommandRunner(logger: logger).run(
-          ['install', '--source', 'path', greetingPath],
+          ['i', '--source', 'path', greetingPath],
         ),
         completion(ExitCode.success.code),
       );

--- a/test/commands/list_test.dart
+++ b/test/commands/list_test.dart
@@ -25,7 +25,7 @@ void main() {
       commandRunner = MasonCommandRunner(logger: logger);
       when(() => logger.progress(any())).thenReturn(([String? _]) {});
       setUpTestingEnvironment(cwd, suffix: '.list');
-      BricksJson.global().clear(force: true);
+      BricksJson.global().clear();
     });
 
     tearDown(() {

--- a/test/commands/new_test.dart
+++ b/test/commands/new_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:io/io.dart';
 import 'package:mason/mason.dart';
+import 'package:mason/src/command.dart';
 import 'package:mason/src/command_runner.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as path;
@@ -33,9 +34,7 @@ void main() {
       final result = await commandRunner.run(['new', 'hello world']);
       expect(result, equals(ExitCode.usage.code));
       verify(
-        () => logger.err(
-          'Could not find mason.yaml.\nDid you forget to run mason init?',
-        ),
+        () => logger.err(const MasonYamlNotFoundException().message),
       ).called(1);
     });
 

--- a/test/commands/uninstall_test.dart
+++ b/test/commands/uninstall_test.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:io/io.dart';
 import 'package:mason/mason.dart';
 import 'package:mason/src/command_runner.dart';
-import 'package:mason/src/mason_cache.dart';
+import 'package:mason/src/bricks_json.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -49,18 +49,18 @@ void main() {
       );
       expect(installResult, equals(ExitCode.success.code));
 
-      final masonYaml = File(p.join(MasonCache.globalDir.path, 'mason.yaml'));
+      final masonYaml = File(p.join(BricksJson.globalDir.path, 'mason.yaml'));
       expect(masonYaml.readAsStringSync(), contains('widget:'));
 
       const key =
           '''widget_536b4405bffd371ab46f0948d0a5b9a2ac2cddb270ebc3d6f684217f7741422f''';
       final value = p.join(
-        MasonCache.rootDir.path,
+        BricksJson.rootDir.path,
         'git',
         '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
       );
       final bricksJson = File(
-        p.join(MasonCache.globalDir.path, '.mason', 'bricks.json'),
+        p.join(BricksJson.globalDir.path, '.mason', 'bricks.json'),
       );
       final bricksJsonContent =
           bricksJson.readAsStringSync().replaceAll(r'\\', r'\');


### PR DESCRIPTION
- feat!: remove `--force` from `mason cache clear`
  - `mason cache clear` will remove all local bricks so `--force` is not necessary
- fix: `mason cache clear` behavior to always clear local and global brick caches
- fix: local and global brick installation conflicts
- fix: `mason list` duplicate bricks
- refactor: `MasonCache` to `BricksJson`
  - simplification of internal APIs and cache implementation