### PR TITLE
feat!: update mason bundle output directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ $ mason i https://github.com/user/repo
 Once a brick is installed globally it can be used from anywhere via the `mason make` command:
 
 ```sh
-$ mason make <NAME-OF-GLOBAL-BRICK>
+$ mason make <BRICK_NAME>
 ```
 
 ## Uninstall Brick Templates
@@ -215,10 +215,10 @@ To generate a bundle:
 
 ```sh
 # Universal Bundle
-mason bundle ./path/to/brick -d ./path/to/destination
+mason bundle ./path/to/brick -o ./path/to/destination
 
 # Dart Bundle
-mason bundle ./path/to/brick -t dart -d ./path/to/destination
+mason bundle ./path/to/brick -t dart -o ./path/to/destination
 ```
 
 ## Usage

--- a/lib/src/commands/bundle.dart
+++ b/lib/src/commands/bundle.dart
@@ -30,13 +30,14 @@ class BundleCommand extends MasonCommand {
       ..addOption(
         'output-dir',
         abbr: 'o',
-        help: 'directory where to output the generated bundle',
+        help: 'Directory where to output the generated bundle.',
         defaultsTo: '.',
       )
       ..addOption(
         'type',
         abbr: 't',
-        help: 'type of bundle to generate (universal or dart)',
+        help: 'Type of bundle to generate.',
+        allowed: ['universal', 'dart'],
         defaultsTo: 'universal',
       );
   }

--- a/lib/src/commands/bundle.dart
+++ b/lib/src/commands/bundle.dart
@@ -28,9 +28,9 @@ class BundleCommand extends MasonCommand {
   BundleCommand({Logger? logger}) : super(logger: logger) {
     argParser
       ..addOption(
-        'destination',
-        abbr: 'd',
-        help: 'destination where to write the generated bundle',
+        'output-dir',
+        abbr: 'o',
+        help: 'directory where to output the generated bundle',
         defaultsTo: '.',
       )
       ..addOption(
@@ -61,19 +61,19 @@ class BundleCommand extends MasonCommand {
     }
 
     final bundle = await createBundle(brick);
-    final destination = results['destination'] as String;
+    final outputDir = results['output-dir'] as String;
     final bundleType = (results['type'] as String).toBundleType();
 
     switch (bundleType) {
       case BundleType.dart:
-        File(path.join(destination, '${bundle.name}_bundle.dart'))
+        File(path.join(outputDir, '${bundle.name}_bundle.dart'))
           ..createSync(recursive: true)
           ..writeAsStringSync(
             "// GENERATED CODE - DO NOT MODIFY BY HAND\n// ignore_for_file: prefer_single_quotes, public_member_api_docs, lines_longer_than_80_chars\n\nimport 'package:mason/mason.dart';\n\nfinal ${bundle.name.camelCase}Bundle = MasonBundle.fromJson(${json.encode(bundle.toJson())});",
           );
         break;
       case BundleType.universal:
-        File(path.join(destination, '${bundle.name}.bundle'))
+        File(path.join(outputDir, '${bundle.name}.bundle'))
           ..createSync(recursive: true)
           ..writeAsStringSync(json.encode(bundle.toJson()));
         break;


### PR DESCRIPTION
### Description

In order to align with other CLI conventions the output directory location option was renamed in the `mason bundle` command.

#### Before

```sh
$ mason bundle ./path/to/brick --directory ./path/to/output/directory

$ mason bundle ./path/to/brick -d ./path/to/output/directory
```

#### After

```sh
$ mason bundle ./path/to/brick --output-dir ./path/to/output/directory

$ mason bundle ./path/to/brick -o ./path/to/output/directory
```

