### PR TITLE
feat!: update mason make command to support a custom output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Hello Felix!
 By default `mason make` will generate the template in the current working directory but a custom output directory can be specified via the `-o` option:
 
 ```sh
-$ mason make hello --name Felix -c ./path/to/directory
+$ mason make hello --name Felix -o ./path/to/directory
 ```
 
 ## Creating New Bricks

--- a/README.md
+++ b/README.md
@@ -70,15 +70,15 @@ $ mason make hello
 name: Felix
 ```
 
-### JSON Input Variables
+### Config File for Input Variables
 
-Any variables can be passed via json file:
+Any variables can be passed via a config file:
 
 ```dart
-$ mason make hello --json hello.json
+$ mason make hello -c config.json
 ```
 
-where `hello.json` is:
+where `config.json` is:
 
 ```json
 {
@@ -90,6 +90,14 @@ The above commands will all generate `HELLO.md` in the current directory with th
 
 ```md
 Hello Felix!
+```
+
+### Custom Output Directory
+
+By default `mason make` will generate the template in the current working directory but a custom output directory can be specified via the `-o` option:
+
+```sh
+$ mason make hello --name Felix -c ./path/to/directory
 ```
 
 ## Creating New Bricks

--- a/example/README.md
+++ b/example/README.md
@@ -21,7 +21,7 @@ Run the following command in the current directory:
 
 ```sh
 mason get # only first time
-mason make todos --json todos.json
+mason make todos -c todos.json
 ```
 
 `TODOS.md` should be created in the current directory with the following contents:

--- a/lib/src/commands/make.dart
+++ b/lib/src/commands/make.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:io/ansi.dart';
 import 'package:io/io.dart';
+import 'package:path/path.dart' as p;
 import 'package:mason/mason.dart';
 import 'package:mason/src/generator.dart';
 
@@ -46,11 +47,18 @@ class MakeCommand extends MasonCommand {
 
 class _MakeCommand extends MasonCommand {
   _MakeCommand(this._brick, {Logger? logger}) : super(logger: logger) {
-    argParser.addOption(
-      'json',
-      abbr: 'j',
-      help: 'Path to json file containing variables',
-    );
+    argParser
+      ..addOption(
+        'config-path',
+        abbr: 'c',
+        help: 'Path to config json file containing variables.',
+      )
+      ..addOption(
+        'output-dir',
+        abbr: 'o',
+        help: 'Directory where to output the generated bundle.',
+        defaultsTo: '.',
+      );
     for (final arg in _brick.vars) {
       argParser.addOption(arg);
     }
@@ -66,7 +74,11 @@ class _MakeCommand extends MasonCommand {
 
   @override
   Future<int> run() async {
-    final target = DirectoryGeneratorTarget(cwd, logger);
+    final outputDir = p.canonicalize(
+      p.join(cwd.path, results['output-dir'] as String),
+    );
+    final configPath = results['config-path'] as String?;
+    final target = DirectoryGeneratorTarget(Directory(outputDir), logger);
 
     Function? generateDone;
     try {
@@ -75,10 +87,10 @@ class _MakeCommand extends MasonCommand {
       generateDone = logger.progress('Making ${generator.id}');
 
       try {
-        vars.addAll(await _decodeFile(results['json'] as String?));
+        vars.addAll(await _decodeFile(configPath));
       } on FormatException catch (error) {
         generateDone();
-        logger.err('${error}in ${results['json']}');
+        logger.err('${error}in $configPath');
         return ExitCode.usage.code;
       } on Exception catch (error) {
         generateDone();
@@ -90,15 +102,11 @@ class _MakeCommand extends MasonCommand {
         if (vars.containsKey(variable)) continue;
         final arg = results[variable] as String?;
         if (arg != null) {
-          vars.addAll(
-            <String, dynamic>{variable: _maybeDecode(arg)},
-          );
+          vars.addAll(<String, dynamic>{variable: _maybeDecode(arg)});
         } else {
-          vars.addAll(
-            <String, dynamic>{
-              variable: _maybeDecode(logger.prompt('$variable: '))
-            },
-          );
+          vars.addAll(<String, dynamic>{
+            variable: _maybeDecode(logger.prompt('$variable: '))
+          });
         }
       }
       final fileCount = await generator.generate(target, vars: vars);
@@ -119,8 +127,8 @@ class _MakeCommand extends MasonCommand {
 
   Future<Map<String, dynamic>> _decodeFile(String? path) async {
     if (path == null) return <String, dynamic>{};
-    final jsonVarsContent = await File(path).readAsString();
-    return json.decode(jsonVarsContent) as Map<String, dynamic>;
+    final content = await File(path).readAsString();
+    return json.decode(content) as Map<String, dynamic>;
   }
 
   dynamic _maybeDecode(String value) {

--- a/lib/src/commands/make.dart
+++ b/lib/src/commands/make.dart
@@ -56,7 +56,7 @@ class _MakeCommand extends MasonCommand {
       ..addOption(
         'output-dir',
         abbr: 'o',
-        help: 'Directory where to output the generated bundle.',
+        help: 'Directory where to output the generated code.',
         defaultsTo: '.',
       );
     for (final arg in _brick.vars) {

--- a/test/commands/make_test.dart
+++ b/test/commands/make_test.dart
@@ -116,7 +116,7 @@ void main() {
       final result = await commandRunner.run([
         'make',
         'todos',
-        '--json',
+        '--config-path',
         'todos.json',
       ]);
       expect(result, equals(ExitCode.usage.code));
@@ -217,7 +217,7 @@ in todos.json''',
       final result = await commandRunner.run([
         'make',
         'todos',
-        '--json',
+        '-c',
         'todos.json',
       ]);
       expect(result, equals(ExitCode.success.code));
@@ -249,6 +249,25 @@ in todos.json''',
       );
       final expected = Directory(
         path.join(testFixturesPath(cwd, suffix: 'make'), 'widget'),
+      );
+      expect(directoriesDeepEqual(actual, expected), isTrue);
+    });
+
+    test('generates greeting with custom output directory', () async {
+      final testDir = Directory(
+        path.join(Directory.current.path, 'output_dir', 'dir'),
+      )..createSync(recursive: true);
+      Directory.current = testDir.path;
+      final result = await commandRunner.run(
+        ['make', 'greeting', '--name', 'test-name', '-o', 'dir'],
+      );
+      expect(result, equals(ExitCode.success.code));
+
+      final actual = Directory(
+        path.join(testFixturesPath(cwd, suffix: '.make'), 'output_dir'),
+      );
+      final expected = Directory(
+        path.join(testFixturesPath(cwd, suffix: 'make'), 'output_dir'),
       );
       expect(directoriesDeepEqual(actual, expected), isTrue);
     });

--- a/test/fixtures/make/output_dir/dir/GREETINGS.md
+++ b/test/fixtures/make/output_dir/dir/GREETINGS.md
@@ -1,0 +1,1 @@
+Hi test-name!


### PR DESCRIPTION
- refactor!: `mason make --json` (`-j`) renamed to `--config-path` (`-c`)
- feat: `mason make` additional option `--output-dir` (`-o`) to specify a custom output directory (closes #76)

### Config File for Input Variables

Any variables can be passed via a config file:

```dart
$ mason make hello -c config.json
```

where `config.json` is:

```json
{
  "name": "Felix"
}
```

### Custom Output Directory

By default `mason make` will generate the template in the current working directory but a custom output directory can be specified via the `-o` option:

```sh
$ mason make hello --name Felix -o ./path/to/directory
```