### PR TITLE
chore: v0.0.1-dev.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # 0.0.1-dev.39
 
-- refactor!: rename `mason make --json` (`-j`) to `mason make --config-path` (`-c`)
-- refactor!: rename `mason bundle --directory` (`-d`) to `mason bundle --output-dir` (`-o`)
 - feat!: update `mason make` to support custom output directory via `--output-dir` (`-o`)
+- refactor!: rename `mason bundle --directory` (`-d`) to `mason bundle --output-dir` (`-o`)
+- refactor!: rename `mason make --json` (`-j`) to `mason make --config-path` (`-c`)
 
 # 0.0.1-dev.38
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.0.1-dev.39
+
+- refactor!: rename `mason make --json` (`-j`) to `mason make --config-path` (`-c`)
+- refactor!: rename `mason bundle --directory` (`-d`) to `mason bundle --output-dir` (`-o`)
+- feat!: update `mason make` to support custom output directory via `--output-dir` (`-o`)
+
 # 0.0.1-dev.38
 
 - feat!: remove `--force` from `mason cache clear`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.0.1-dev.38';
+const packageVersion = '0.0.1-dev.39';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mason
 description: >
   A Dart template generator which helps teams generate files quickly and consistently.
-version: 0.0.1-dev.38
+version: 0.0.1-dev.39
 homepage: https://github.com/felangel/mason
 
 environment:


### PR DESCRIPTION
- refactor!: rename `mason make --json` (`-j`) to `mason make --config-path` (`-c`)
- refactor!: rename `mason bundle --directory` (`-d`) to `mason bundle --output-dir` (`-o`)
- feat!: update `mason make` to support custom output directory via `--output-dir` (`-o`)