### PR TITLE
fix: create target directory if not existent

### DIFF
--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -183,7 +183,7 @@ abstract class Generator implements Comparable<Generator> {
 class DirectoryGeneratorTarget extends GeneratorTarget {
   /// {@macro directory_generator_target}
   DirectoryGeneratorTarget(this.dir, this.logger) {
-    dir.createSync();
+    dir.createSync(recursive: true);
   }
 
   /// The target [Directory].

--- a/test/commands/make_test.dart
+++ b/test/commands/make_test.dart
@@ -255,7 +255,7 @@ in todos.json''',
 
     test('generates greeting with custom output directory', () async {
       final testDir = Directory(
-        path.join(Directory.current.path, 'output_dir', 'dir'),
+        path.join(Directory.current.path, 'output_dir'),
       )..createSync(recursive: true);
       Directory.current = testDir.path;
       final result = await commandRunner.run(

--- a/test/commands/make_test.dart
+++ b/test/commands/make_test.dart
@@ -254,20 +254,23 @@ in todos.json''',
     });
 
     test('generates greeting with custom output directory', () async {
-      final testDir = Directory(
-        path.join(Directory.current.path, 'output_dir'),
-      )..createSync(recursive: true);
-      Directory.current = testDir.path;
       final result = await commandRunner.run(
-        ['make', 'greeting', '--name', 'test-name', '-o', 'dir'],
+        [
+          'make',
+          'greeting',
+          '--name',
+          'test-name',
+          '-o',
+          path.join('output_dir', 'dir')
+        ],
       );
       expect(result, equals(ExitCode.success.code));
 
       final actual = Directory(
-        path.join(testFixturesPath(cwd, suffix: '.make'), 'output_dir'),
+        path.join(testFixturesPath(cwd, suffix: '.make'), 'output_dir', 'dir'),
       );
       final expected = Directory(
-        path.join(testFixturesPath(cwd, suffix: 'make'), 'output_dir'),
+        path.join(testFixturesPath(cwd, suffix: 'make'), 'output_dir', 'dir'),
       );
       expect(directoriesDeepEqual(actual, expected), isTrue);
     });


### PR DESCRIPTION
`mason make <BRICK_NAME> -o ./path/to/custom/directory` will create the target directory recursively if it doesn't already exist