### PR TITLE
chore: v0.0.1-dev.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.0.1-dev.42
+
+- fix: improve `mason make --help` to show complete usage information
+
+  ```sh
+  Generate code using an existing brick template.
+
+  Usage: mason make [arguments]
+  -h, --help           Print this usage information.
+  -c, --config-path    Path to config json file containing variables.
+  -o, --output-dir     Directory where to output the generated code.
+                      (defaults to ".")
+
+  Run "mason help" to see global options.
+  ```
+
 # 0.0.1-dev.41
 
 - feat: add `OverwriteRule` for file conflict resolution (`Yna`)

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.0.1-dev.41';
+const packageVersion = '0.0.1-dev.42';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mason
 description: >
   A Dart template generator which helps teams generate files quickly and consistently.
-version: 0.0.1-dev.41
+version: 0.0.1-dev.42
 homepage: https://github.com/felangel/mason
 
 environment:


### PR DESCRIPTION
- fix: improve `mason make --help` to show complete usage information

  ```sh
  Generate code using an existing brick template.

  Usage: mason make [arguments]
  -h, --help           Print this usage information.
  -c, --config-path    Path to config json file containing variables.
  -o, --output-dir     Directory where to output the generated code.
                      (defaults to ".")

  Run "mason help" to see global options.
  ```