### PR TITLE
chore: v0.0.1-dev.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.1-dev.45
+
+- fix: `mason bundle` add `.otf` support.
+
 # 0.0.1-dev.44
 
 - feat: custom file conflict resolution via `mason make --on-conflict`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.0.1-dev.44';
+const packageVersion = '0.0.1-dev.45';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mason
 description: >
   A Dart template generator which helps teams generate files quickly and consistently.
-version: 0.0.1-dev.44
+version: 0.0.1-dev.45
 homepage: https://github.com/felangel/mason
 
 environment:


### PR DESCRIPTION
- fix: `mason bundle` add `.otf` support.