### PR TITLE
fix: brick.yaml vars should be optional

### DIFF
--- a/bricks/simple/__brick__/HELLO.md
+++ b/bricks/simple/__brick__/HELLO.md
@@ -1,0 +1,1 @@
+Hello World!

--- a/bricks/simple/brick.yaml
+++ b/bricks/simple/brick.yaml
@@ -1,0 +1,2 @@
+name: simple
+description: A Simple Static Template

--- a/example/mason.yaml
+++ b/example/mason.yaml
@@ -7,6 +7,8 @@ bricks:
     path: ../bricks/greeting
   hello_world:
     path: ../bricks/hello_world
+  simple:
+    path: ../bricks/simple
   todos:
     path: ../bricks/todos
   widget:

--- a/lib/src/brick_yaml.dart
+++ b/lib/src/brick_yaml.dart
@@ -38,6 +38,7 @@ class BrickYaml {
   final String description;
 
   /// List of variables used when templating a brick.
+  @JsonKey(defaultValue: <String>[])
   final List<String> vars;
 
   /// Path to the [BrickYaml] file.

--- a/lib/src/brick_yaml.g.dart
+++ b/lib/src/brick_yaml.g.dart
@@ -14,7 +14,8 @@ BrickYaml _$BrickYamlFromJson(Map json) {
       $checkedConvert(json, 'name', (v) => v as String),
       $checkedConvert(json, 'description', (v) => v as String),
       vars: $checkedConvert(json, 'vars',
-          (v) => (v as List<dynamic>).map((e) => e as String).toList()),
+              (v) => (v as List<dynamic>?)?.map((e) => e as String).toList()) ??
+          [],
       path: $checkedConvert(json, 'path', (v) => v as String?),
     );
     return val;

--- a/test/commands/get_test.dart
+++ b/test/commands/get_test.dart
@@ -35,6 +35,8 @@ void main() {
     path: ../../bricks/documentation
   greeting:
     path: ../../bricks/greeting
+  simple:
+    path: ../../bricks/simple
   todos:
     path: ../../bricks/todos
   widget:
@@ -76,6 +78,9 @@ void main() {
       final greetingPath = path.canonicalize(
         path.join(Directory.current.path, bricksPath, 'greeting'),
       );
+      final simplePath = path.canonicalize(
+        path.join(Directory.current.path, bricksPath, 'simple'),
+      );
       final todosPath = path.canonicalize(
         path.join(Directory.current.path, bricksPath, 'todos'),
       );
@@ -97,6 +102,8 @@ void main() {
                 docPath,
             '''greeting_a4652001e26be10014b29359c36b1e52c04faf4ef12c0d9560e73d2f0c2641f8''':
                 greetingPath,
+            '''simple_f693a3ce2317548ff338ea9905d5e60c6b25da961520f77d0282094da778acc5''':
+                simplePath,
             '''todos_73b2e1ae179e296b318703953a86f28a792e94bed4a9adec9f8ee5893c4527a7''':
                 todosPath,
             widgetPath: masonUrl,

--- a/test/commands/make_test.dart
+++ b/test/commands/make_test.dart
@@ -31,7 +31,9 @@ void main() {
   greeting:
     path: ../../../bricks/greeting
   hello_world:
-    path: ../bricks/hello_world
+    path: ../../../bricks/hello_world
+  simple:
+    path: ../../../bricks/simple
   todos:
     path: ../../../bricks/todos
   widget:
@@ -50,6 +52,9 @@ void main() {
       final helloWorldPath = path.canonicalize(
         path.join(Directory.current.path, bricksPath, 'hello_world'),
       );
+      final simplePath = path.canonicalize(
+        path.join(Directory.current.path, bricksPath, 'simple'),
+      );
       final todosPath = path.canonicalize(
         path.join(Directory.current.path, bricksPath, 'todos'),
       );
@@ -65,8 +70,10 @@ void main() {
               docPath,
           '''greeting_81a4ec348561cdd721c3bb79b3d6dc14738bf17f02e18810dad2a6d88732e298''':
               greetingPath,
-          '''hello_world_6bb398ce3cd00f53423469ca6f0fbe8e6ee49a7351c5bf45de7faff464d31333''':
+          '''hello_world_fd66b903d5885651238b50e1205b0cf05f30573cc3b4a7a4f2d1f495edd33630''':
               helloWorldPath,
+          '''simple_3bbc2ade88745ef690063c8f652631a4870ee6af619a327e297084251aebe232''':
+              simplePath,
           '''todos_6d110323da1d9f3a3ae2ecc6feae02edef8af68ca329601f33ee29e725f1f740''':
               todosPath,
           '''widget_02426be7ece33230d574cb7a76eb7a9a595a79cbf53a1b1c8f2f1de78dfbe23f''':
@@ -102,6 +109,7 @@ void main() {
             '  documentation   Create Documentation Markdown Files\n'
             '  greeting        A Simple Greeting Template\n'
             '  hello_world     A Simple Hello World Template\n'
+            '  simple          A Simple Static Template\n'
             '  todos           A Todos Template\n'
             '  widget          Create a Simple Flutter Widget\n'
             '\n'
@@ -286,6 +294,23 @@ in todos.json''',
       );
       final expected = Directory(
         path.join(testFixturesPath(cwd, suffix: 'make'), 'hello_world'),
+      );
+      expect(directoriesDeepEqual(actual, expected), isTrue);
+    });
+
+    test('generates simple', () async {
+      final testDir = Directory(
+        path.join(Directory.current.path, 'simple'),
+      )..createSync(recursive: true);
+      Directory.current = testDir.path;
+      final result = await commandRunner.run(['make', 'simple']);
+      expect(result, equals(ExitCode.success.code));
+
+      final actual = Directory(
+        path.join(testFixturesPath(cwd, suffix: '.make'), 'simple'),
+      );
+      final expected = Directory(
+        path.join(testFixturesPath(cwd, suffix: 'make'), 'simple'),
       );
       expect(directoriesDeepEqual(actual, expected), isTrue);
     });

--- a/test/fixtures/make/simple/HELLO.md
+++ b/test/fixtures/make/simple/HELLO.md
@@ -1,0 +1,1 @@
+Hello World!


### PR DESCRIPTION
## Description

As a developer, I should be able to define a brick without any variables:

```yaml
name: simple
description: A Simple Static Template
```