### PR TITLE
feat: add exclude option in brick yaml

### DIFF
--- a/lib/src/brick_yaml.dart
+++ b/lib/src/brick_yaml.dart
@@ -13,6 +13,7 @@ class BrickYaml {
     this.name,
     this.description, {
     this.vars = const <String>[],
+    this.exclude = const <String>[],
     this.path,
   });
 
@@ -45,13 +46,18 @@ class BrickYaml {
   @JsonKey(defaultValue: <String>[])
   final List<String> vars;
 
+  /// List of paths to exclude when templating a brick.
+  @JsonKey(defaultValue: <String>[])
+  final List<String> exclude;
+
   /// Path to the [BrickYaml] file.
   final String? path;
 
   /// Returns a copy of the current [BrickYaml] with
   /// an overridden [path].
   BrickYaml copyWith({String? path}) {
-    return BrickYaml(name, description, vars: vars, path: path ?? this.path);
+    return BrickYaml(name, description,
+        vars: vars, exclude: exclude, path: path ?? this.path);
   }
 
   @override

--- a/lib/src/brick_yaml.g.dart
+++ b/lib/src/brick_yaml.g.dart
@@ -9,11 +9,14 @@ part of 'brick_yaml.dart';
 BrickYaml _$BrickYamlFromJson(Map json) {
   return $checkedNew('BrickYaml', json, () {
     $checkKeys(json,
-        allowedKeys: const ['name', 'description', 'vars', 'path']);
+        allowedKeys: const ['name', 'description', 'vars', 'exclude', 'path']);
     final val = BrickYaml(
       $checkedConvert(json, 'name', (v) => v as String),
       $checkedConvert(json, 'description', (v) => v as String),
       vars: $checkedConvert(json, 'vars',
+              (v) => (v as List<dynamic>?)?.map((e) => e as String).toList()) ??
+          [],
+      exclude: $checkedConvert(json, 'exclude',
               (v) => (v as List<dynamic>?)?.map((e) => e as String).toList()) ??
           [],
       path: $checkedConvert(json, 'path', (v) => v as String?),
@@ -27,6 +30,7 @@ Map<String, dynamic> _$BrickYamlToJson(BrickYaml instance) {
     'name': instance.name,
     'description': instance.description,
     'vars': instance.vars,
+    'exclude': instance.exclude,
   };
 
   void writeNotNull(String key, dynamic value) {


### PR DESCRIPTION
## Status

**READY**

## Description

Added the `exclude` option in brick.yaml, to give users more control over what should be included in a bundle:
```yaml
name: hello
description: An example hello brick.
vars:
  - name
exclude:
  - .dart_tool/**
  - pubspec.lock
```

Related issue: https://github.com/felangel/mason/issues/166

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Testing

I did not see any existing tests related to bundle. Thus, I only test the new feature manually.


