### PR TITLE
feat: brick advanced variable support

### DIFF
--- a/bricks/bio/__brick__/ABOUT.md
+++ b/bricks/bio/__brick__/ABOUT.md
@@ -1,0 +1,3 @@
+# About
+
+Hello, my name is {{name}}! I am {{age}} years old and I {{#isDeveloper}}am{{/isDeveloper}}{{^isDeveloper}}am not{{/isDeveloper}} a developer.

--- a/bricks/bio/brick.yaml
+++ b/bricks/bio/brick.yaml
@@ -1,0 +1,19 @@
+name: bio
+description: A Bio Template
+version: 1.0.0
+vars:
+  name:
+    type: string
+    description: Name of the current user
+    default: Dash
+    prompt: What is your name?
+  age:
+    type: number
+    description: Age of the current user
+    default: 42
+    prompt: How old are you?
+  isDeveloper:
+    type: boolean
+    description: If the current user is a developer
+    default: false
+    prompt: Are you a developer?

--- a/packages/mason/lib/mason.dart
+++ b/packages/mason/lib/mason.dart
@@ -6,7 +6,8 @@ library mason;
 
 export 'package:mason_logger/mason_logger.dart';
 
-export 'src/brick_yaml.dart' show BrickYaml, BrickVariable, BrickVariableType;
+export 'src/brick_yaml.dart'
+    show BrickYaml, BrickVariableProperties, BrickVariableType;
 export 'src/bricks_json.dart' show BricksJson;
 export 'src/bundler.dart' show createBundle;
 export 'src/exception.dart'

--- a/packages/mason/lib/mason.dart
+++ b/packages/mason/lib/mason.dart
@@ -6,7 +6,7 @@ library mason;
 
 export 'package:mason_logger/mason_logger.dart';
 
-export 'src/brick_yaml.dart' show BrickYaml;
+export 'src/brick_yaml.dart' show BrickYaml, BrickVariable, BrickVariableType;
 export 'src/bricks_json.dart' show BricksJson;
 export 'src/bundler.dart' show createBundle;
 export 'src/exception.dart'

--- a/packages/mason/lib/src/brick_yaml.dart
+++ b/packages/mason/lib/src/brick_yaml.dart
@@ -17,7 +17,7 @@ class BrickYaml {
     required this.name,
     required this.description,
     required this.version,
-    this.vars = const <String, BrickVariable>{},
+    this.vars = const <String, BrickVariableProperties>{},
     this.path,
   });
 
@@ -49,9 +49,9 @@ class BrickYaml {
   /// Version of the brick (semver).
   final String version;
 
-  /// Map of variable name to [BrickVariable] used when templating a brick.
+  /// Map of variable properties used when templating a brick.
   @VarsConverter()
-  final Map<String, BrickVariable> vars;
+  final Map<String, BrickVariableProperties> vars;
 
   /// Path to the [BrickYaml] file.
   final String? path;
@@ -90,26 +90,26 @@ enum BrickVariableType {
   boolean,
 }
 
-/// {@template brick_variable}
+/// {@template brick_variable_properties}
 /// An object representing a brick variable.
 /// {@endtemplate}
 @immutable
 @JsonSerializable()
-class BrickVariable {
-  /// {@macro brick_variable}
+class BrickVariableProperties {
+  /// {@macro brick_variable_properties}
   @internal
-  const BrickVariable({
+  const BrickVariableProperties({
     required this.type,
     this.description,
     this.defaultValue,
     this.prompt,
   });
 
-  /// {@macro brick_variable}
+  /// {@macro brick_variable_properties}
   ///
-  /// Creates an instance of a [BrickVariable]
+  /// Creates an instance of a [BrickVariableProperties]
   /// of type [BrickVariableType.string].
-  const BrickVariable.string({
+  const BrickVariableProperties.string({
     String? description,
     String? defaultValue,
     String? prompt,
@@ -120,11 +120,11 @@ class BrickVariable {
           prompt: prompt,
         );
 
-  /// {@macro brick_variable}
+  /// {@macro brick_variable_properties}
   ///
-  /// Creates an instance of a [BrickVariable]
+  /// Creates an instance of a [BrickVariableProperties]
   /// of type [BrickVariableType.boolean].
-  const BrickVariable.boolean({
+  const BrickVariableProperties.boolean({
     String? description,
     bool? defaultValue,
     String? prompt,
@@ -135,11 +135,11 @@ class BrickVariable {
           prompt: prompt,
         );
 
-  /// {@macro brick_variable}
+  /// {@macro brick_variable_properties}
   ///
-  /// Creates an instance of a [BrickVariable]
+  /// Creates an instance of a [BrickVariableProperties]
   /// of type [BrickVariableType.number].
-  const BrickVariable.number({
+  const BrickVariableProperties.number({
     String? description,
     num? defaultValue,
     String? prompt,
@@ -151,11 +151,11 @@ class BrickVariable {
         );
 
   /// Converts [Map] to [BrickYaml]
-  factory BrickVariable.fromJson(Map<dynamic, dynamic> json) =>
-      _$BrickVariableFromJson(json);
+  factory BrickVariableProperties.fromJson(Map<dynamic, dynamic> json) =>
+      _$BrickVariablePropertiesFromJson(json);
 
-  /// Converts [BrickVariable] to [Map]
-  Map<dynamic, dynamic> toJson() => _$BrickVariableToJson(this);
+  /// Converts [BrickVariableProperties] to [Map]
+  Map<dynamic, dynamic> toJson() => _$BrickVariablePropertiesToJson(this);
 
   /// The type of the variable.
   final BrickVariableType type;
@@ -172,31 +172,32 @@ class BrickVariable {
 }
 
 /// {@template vars_converter}
-/// Json Converter for [Map<String, BrickVariable>].
+/// Json Converter for [Map<String, BrickVariableProperties>].
 /// {@endtemplate}
 class VarsConverter
-    implements JsonConverter<Map<String, BrickVariable>, dynamic> {
+    implements JsonConverter<Map<String, BrickVariableProperties>, dynamic> {
   /// {@macro vars_converter}
   const VarsConverter();
 
   @override
-  dynamic toJson(Map<String, BrickVariable> value) {
+  dynamic toJson(Map<String, BrickVariableProperties> value) {
     return value.map((key, value) => MapEntry(key, value.toJson()));
   }
 
   @override
-  Map<String, BrickVariable> fromJson(dynamic value) {
+  Map<String, BrickVariableProperties> fromJson(dynamic value) {
     final dynamic _value = value is String ? json.decode(value) : value;
     if (_value is List) {
-      return <String, BrickVariable>{
-        for (var v in _value) v as String: const BrickVariable.string(),
+      return <String, BrickVariableProperties>{
+        for (final v in _value)
+          v as String: const BrickVariableProperties.string(),
       };
     }
     if (_value is Map) {
       return _value.map(
         (dynamic key, dynamic value) => MapEntry(
           key as String,
-          BrickVariable.fromJson(_value[key] as Map),
+          BrickVariableProperties.fromJson(_value[key] as Map),
         ),
       );
     }

--- a/packages/mason/lib/src/brick_yaml.dart
+++ b/packages/mason/lib/src/brick_yaml.dart
@@ -10,7 +10,7 @@ part 'brick_yaml.g.dart';
 /// a `MasonGenerator` from a brick template.
 /// {@endtemplate}
 @immutable
-@JsonSerializable(checked: false)
+@JsonSerializable()
 class BrickYaml {
   /// {@macro mason_yaml}
   const BrickYaml({
@@ -102,39 +102,52 @@ class BrickVariable {
     required this.type,
     this.description,
     this.defaultValue,
+    this.prompt,
   });
 
   /// {@macro brick_variable}
   ///
   /// Creates an instance of a [BrickVariable]
   /// of type [BrickVariableType.string].
-  const BrickVariable.string({String? description, String? defaultValue})
-      : this(
+  const BrickVariable.string({
+    String? description,
+    String? defaultValue,
+    String? prompt,
+  }) : this(
           type: BrickVariableType.string,
           description: description,
           defaultValue: defaultValue,
+          prompt: prompt,
         );
 
   /// {@macro brick_variable}
   ///
   /// Creates an instance of a [BrickVariable]
   /// of type [BrickVariableType.boolean].
-  const BrickVariable.boolean({String? description, bool? defaultValue})
-      : this(
+  const BrickVariable.boolean({
+    String? description,
+    bool? defaultValue,
+    String? prompt,
+  }) : this(
           type: BrickVariableType.boolean,
           description: description,
           defaultValue: defaultValue,
+          prompt: prompt,
         );
 
   /// {@macro brick_variable}
   ///
   /// Creates an instance of a [BrickVariable]
   /// of type [BrickVariableType.number].
-  const BrickVariable.number({String? description, num? defaultValue})
-      : this(
+  const BrickVariable.number({
+    String? description,
+    num? defaultValue,
+    String? prompt,
+  }) : this(
           type: BrickVariableType.number,
           description: description,
           defaultValue: defaultValue,
+          prompt: prompt,
         );
 
   /// Converts [Map] to [BrickYaml]
@@ -153,6 +166,9 @@ class BrickVariable {
   /// An optional default value for the variable.
   @JsonKey(name: 'default')
   final Object? defaultValue;
+
+  /// An optional prompt used when requesting the variable.
+  final String? prompt;
 }
 
 /// {@template vars_converter}

--- a/packages/mason/lib/src/brick_yaml.g.dart
+++ b/packages/mason/lib/src/brick_yaml.g.dart
@@ -6,21 +6,28 @@ part of 'brick_yaml.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-BrickYaml _$BrickYamlFromJson(Map json) {
-  $checkKeys(
-    json,
-    allowedKeys: const ['name', 'description', 'version', 'vars', 'path'],
-  );
-  return BrickYaml(
-    name: json['name'] as String,
-    description: json['description'] as String,
-    version: json['version'] as String,
-    vars: json['vars'] == null
-        ? const <String, BrickVariable>{}
-        : const VarsConverter().fromJson(json['vars']),
-    path: json['path'] as String?,
-  );
-}
+BrickYaml _$BrickYamlFromJson(Map json) => $checkedCreate(
+      'BrickYaml',
+      json,
+      ($checkedConvert) {
+        $checkKeys(
+          json,
+          allowedKeys: const ['name', 'description', 'version', 'vars', 'path'],
+        );
+        final val = BrickYaml(
+          name: $checkedConvert('name', (v) => v as String),
+          description: $checkedConvert('description', (v) => v as String),
+          version: $checkedConvert('version', (v) => v as String),
+          vars: $checkedConvert(
+              'vars',
+              (v) => v == null
+                  ? const <String, BrickVariable>{}
+                  : const VarsConverter().fromJson(v)),
+          path: $checkedConvert('path', (v) => v as String?),
+        );
+        return val;
+      },
+    );
 
 Map<String, dynamic> _$BrickYamlToJson(BrickYaml instance) {
   final val = <String, dynamic>{
@@ -46,13 +53,14 @@ BrickVariable _$BrickVariableFromJson(Map json) => $checkedCreate(
       ($checkedConvert) {
         $checkKeys(
           json,
-          allowedKeys: const ['type', 'description', 'default'],
+          allowedKeys: const ['type', 'description', 'default', 'prompt'],
         );
         final val = BrickVariable(
           type: $checkedConvert(
               'type', (v) => $enumDecode(_$BrickVariableTypeEnumMap, v)),
           description: $checkedConvert('description', (v) => v as String?),
           defaultValue: $checkedConvert('default', (v) => v),
+          prompt: $checkedConvert('prompt', (v) => v as String?),
         );
         return val;
       },
@@ -72,6 +80,7 @@ Map<String, dynamic> _$BrickVariableToJson(BrickVariable instance) {
 
   writeNotNull('description', instance.description);
   writeNotNull('default', instance.defaultValue);
+  writeNotNull('prompt', instance.prompt);
   return val;
 }
 

--- a/packages/mason/lib/src/brick_yaml.g.dart
+++ b/packages/mason/lib/src/brick_yaml.g.dart
@@ -21,7 +21,7 @@ BrickYaml _$BrickYamlFromJson(Map json) => $checkedCreate(
           vars: $checkedConvert(
               'vars',
               (v) => v == null
-                  ? const <String, BrickVariable>{}
+                  ? const <String, BrickVariableProperties>{}
                   : const VarsConverter().fromJson(v)),
           path: $checkedConvert('path', (v) => v as String?),
         );
@@ -47,15 +47,16 @@ Map<String, dynamic> _$BrickYamlToJson(BrickYaml instance) {
   return val;
 }
 
-BrickVariable _$BrickVariableFromJson(Map json) => $checkedCreate(
-      'BrickVariable',
+BrickVariableProperties _$BrickVariablePropertiesFromJson(Map json) =>
+    $checkedCreate(
+      'BrickVariableProperties',
       json,
       ($checkedConvert) {
         $checkKeys(
           json,
           allowedKeys: const ['type', 'description', 'default', 'prompt'],
         );
-        final val = BrickVariable(
+        final val = BrickVariableProperties(
           type: $checkedConvert(
               'type', (v) => $enumDecode(_$BrickVariableTypeEnumMap, v)),
           description: $checkedConvert('description', (v) => v as String?),
@@ -67,7 +68,8 @@ BrickVariable _$BrickVariableFromJson(Map json) => $checkedCreate(
       fieldKeyMap: const {'defaultValue': 'default'},
     );
 
-Map<String, dynamic> _$BrickVariableToJson(BrickVariable instance) {
+Map<String, dynamic> _$BrickVariablePropertiesToJson(
+    BrickVariableProperties instance) {
   final val = <String, dynamic>{
     'type': _$BrickVariableTypeEnumMap[instance.type],
   };

--- a/packages/mason/lib/src/brick_yaml.g.dart
+++ b/packages/mason/lib/src/brick_yaml.g.dart
@@ -6,35 +6,27 @@ part of 'brick_yaml.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-BrickYaml _$BrickYamlFromJson(Map json) => $checkedCreate(
-      'BrickYaml',
-      json,
-      ($checkedConvert) {
-        $checkKeys(
-          json,
-          allowedKeys: const ['name', 'description', 'version', 'vars', 'path'],
-        );
-        final val = BrickYaml(
-          name: $checkedConvert('name', (v) => v as String),
-          description: $checkedConvert('description', (v) => v as String),
-          version: $checkedConvert('version', (v) => v as String),
-          vars: $checkedConvert(
-              'vars',
-              (v) =>
-                  (v as List<dynamic>?)?.map((e) => e as String).toList() ??
-                  const <String>[]),
-          path: $checkedConvert('path', (v) => v as String?),
-        );
-        return val;
-      },
-    );
+BrickYaml _$BrickYamlFromJson(Map json) {
+  $checkKeys(
+    json,
+    allowedKeys: const ['name', 'description', 'version', 'vars', 'path'],
+  );
+  return BrickYaml(
+    name: json['name'] as String,
+    description: json['description'] as String,
+    version: json['version'] as String,
+    vars: json['vars'] == null
+        ? const <String, BrickVariable>{}
+        : const VarsConverter().fromJson(json['vars']),
+    path: json['path'] as String?,
+  );
+}
 
 Map<String, dynamic> _$BrickYamlToJson(BrickYaml instance) {
   final val = <String, dynamic>{
     'name': instance.name,
     'description': instance.description,
     'version': instance.version,
-    'vars': instance.vars,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -43,6 +35,48 @@ Map<String, dynamic> _$BrickYamlToJson(BrickYaml instance) {
     }
   }
 
+  writeNotNull('vars', const VarsConverter().toJson(instance.vars));
   writeNotNull('path', instance.path);
   return val;
 }
+
+BrickVariable _$BrickVariableFromJson(Map json) => $checkedCreate(
+      'BrickVariable',
+      json,
+      ($checkedConvert) {
+        $checkKeys(
+          json,
+          allowedKeys: const ['type', 'description', 'default'],
+        );
+        final val = BrickVariable(
+          type: $checkedConvert(
+              'type', (v) => $enumDecode(_$BrickVariableTypeEnumMap, v)),
+          description: $checkedConvert('description', (v) => v as String?),
+          defaultValue: $checkedConvert('default', (v) => v),
+        );
+        return val;
+      },
+      fieldKeyMap: const {'defaultValue': 'default'},
+    );
+
+Map<String, dynamic> _$BrickVariableToJson(BrickVariable instance) {
+  final val = <String, dynamic>{
+    'type': _$BrickVariableTypeEnumMap[instance.type],
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('description', instance.description);
+  writeNotNull('default', instance.defaultValue);
+  return val;
+}
+
+const _$BrickVariableTypeEnumMap = {
+  BrickVariableType.number: 'number',
+  BrickVariableType.string: 'string',
+  BrickVariableType.boolean: 'boolean',
+};

--- a/packages/mason/lib/src/generator.dart
+++ b/packages/mason/lib/src/generator.dart
@@ -83,7 +83,7 @@ class MasonGenerator extends Generator {
     return MasonGenerator(
       brick.name,
       brick.description,
-      vars: brick.vars,
+      vars: brick.vars.keys.toList(),
       files: await Future.wait(brickFiles),
       hooks: await GeneratorHooks.fromBrickYaml(brick),
     );
@@ -95,7 +95,7 @@ class MasonGenerator extends Generator {
     return MasonGenerator(
       bundle.name,
       bundle.description,
-      vars: bundle.vars,
+      vars: bundle.vars.keys.toList(),
       files: _decodeConcatenatedData(bundle.files),
       hooks: GeneratorHooks.fromBundle(bundle),
     );

--- a/packages/mason/lib/src/mason_bundle.dart
+++ b/packages/mason/lib/src/mason_bundle.dart
@@ -1,4 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:mason/src/brick_yaml.dart';
 
 part 'mason_bundle.g.dart';
 
@@ -59,7 +60,8 @@ class MasonBundle {
   final String description;
 
   /// All required variables for the brick (from the `brick.yaml`).
-  final List<String> vars;
+  @VarsConverter()
+  final Map<String, BrickVariable> vars;
 
   /// Converts a [MasonBundle] into a [Map<String, dynamic>].
   Map<String, dynamic> toJson() => _$MasonBundleToJson(this);

--- a/packages/mason/lib/src/mason_bundle.dart
+++ b/packages/mason/lib/src/mason_bundle.dart
@@ -61,7 +61,7 @@ class MasonBundle {
 
   /// All required variables for the brick (from the `brick.yaml`).
   @VarsConverter()
-  final Map<String, BrickVariable> vars;
+  final Map<String, BrickVariableProperties> vars;
 
   /// Converts a [MasonBundle] into a [Map<String, dynamic>].
   Map<String, dynamic> toJson() => _$MasonBundleToJson(this);

--- a/packages/mason/lib/src/mason_bundle.g.dart
+++ b/packages/mason/lib/src/mason_bundle.g.dart
@@ -41,8 +41,7 @@ MasonBundle _$MasonBundleFromJson(Map json) => $checkedCreate(
         final val = MasonBundle(
           $checkedConvert('name', (v) => v as String),
           $checkedConvert('description', (v) => v as String),
-          $checkedConvert('vars',
-              (v) => (v as List<dynamic>).map((e) => e as String).toList()),
+          $checkedConvert('vars', (v) => const VarsConverter().fromJson(v)),
           $checkedConvert(
               'files',
               (v) => (v as List<dynamic>)
@@ -62,11 +61,20 @@ MasonBundle _$MasonBundleFromJson(Map json) => $checkedCreate(
       },
     );
 
-Map<String, dynamic> _$MasonBundleToJson(MasonBundle instance) =>
-    <String, dynamic>{
-      'files': instance.files.map((e) => e.toJson()).toList(),
-      'hooks': instance.hooks.map((e) => e.toJson()).toList(),
-      'name': instance.name,
-      'description': instance.description,
-      'vars': instance.vars,
-    };
+Map<String, dynamic> _$MasonBundleToJson(MasonBundle instance) {
+  final val = <String, dynamic>{
+    'files': instance.files.map((e) => e.toJson()).toList(),
+    'hooks': instance.hooks.map((e) => e.toJson()).toList(),
+    'name': instance.name,
+    'description': instance.description,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('vars', const VarsConverter().toJson(instance.vars));
+  return val;
+}

--- a/packages/mason/pubspec.yaml
+++ b/packages/mason/pubspec.yaml
@@ -29,3 +29,7 @@ dev_dependencies:
   mocktail: ^0.2.0
   test: ^1.17.0
   very_good_analysis: ^2.4.0
+
+dependency_overrides:
+  mason_logger:
+    path: ../mason_logger

--- a/packages/mason/test/src/brick_yaml_test.dart
+++ b/packages/mason/test/src/brick_yaml_test.dart
@@ -4,13 +4,13 @@ import 'package:checked_yaml/checked_yaml.dart';
 import 'package:mason/mason.dart';
 import 'package:test/test.dart';
 
-Matcher isBrickVariable({
+Matcher equalsBrickVariableProperties({
   required BrickVariableType type,
   String? description,
   dynamic defaultValue,
   String? prompt,
 }) {
-  return isA<BrickVariable>()
+  return isA<BrickVariableProperties>()
       .having((v) => v.type, 'type', type)
       .having((v) => v.description, 'description', description)
       .having((v) => v.defaultValue, 'default', defaultValue)
@@ -37,17 +37,17 @@ void main() {
           version: '1.0.0',
           // ignore: prefer_const_literals_to_create_immutables
           vars: {
-            'name': BrickVariable.string(
+            'name': BrickVariableProperties.string(
               description: 'the name',
               defaultValue: 'Dash',
               prompt: 'What is your name?',
             ),
-            'age': BrickVariable.number(
+            'age': BrickVariableProperties.number(
               description: 'the age',
               defaultValue: 42,
               prompt: 'How old are you?',
             ),
-            'isDeveloper': BrickVariable.boolean(
+            'isDeveloper': BrickVariableProperties.boolean(
               description: 'whether you are a developer',
               defaultValue: true,
               prompt: 'Are you a developer?',
@@ -79,9 +79,9 @@ vars:
         expect(
           brickYaml.vars.values,
           equals([
-            isBrickVariable(type: BrickVariableType.string),
-            isBrickVariable(type: BrickVariableType.string),
-            isBrickVariable(type: BrickVariableType.string),
+            equalsBrickVariableProperties(type: BrickVariableType.string),
+            equalsBrickVariableProperties(type: BrickVariableType.string),
+            equalsBrickVariableProperties(type: BrickVariableType.string),
           ]),
         );
       });
@@ -120,19 +120,19 @@ vars:
         expect(
           brickYaml.vars.values,
           equals([
-            isBrickVariable(
+            equalsBrickVariableProperties(
               type: BrickVariableType.string,
               description: 'the name',
               defaultValue: 'Dash',
               prompt: 'What is your name?',
             ),
-            isBrickVariable(
+            equalsBrickVariableProperties(
               type: BrickVariableType.number,
               description: 'the age',
               defaultValue: 42,
               prompt: 'How old are you?',
             ),
-            isBrickVariable(
+            equalsBrickVariableProperties(
               type: BrickVariableType.boolean,
               description: 'whether you are a developer',
               defaultValue: true,

--- a/packages/mason/test/src/brick_yaml_test.dart
+++ b/packages/mason/test/src/brick_yaml_test.dart
@@ -8,11 +8,13 @@ Matcher isBrickVariable({
   required BrickVariableType type,
   String? description,
   dynamic defaultValue,
+  String? prompt,
 }) {
   return isA<BrickVariable>()
       .having((v) => v.type, 'type', type)
       .having((v) => v.description, 'description', description)
-      .having((v) => v.defaultValue, 'default', defaultValue);
+      .having((v) => v.defaultValue, 'default', defaultValue)
+      .having((v) => v.prompt, 'prompt', prompt);
 }
 
 void main() {
@@ -38,14 +40,17 @@ void main() {
             'name': BrickVariable.string(
               description: 'the name',
               defaultValue: 'Dash',
+              prompt: 'What is your name?',
             ),
             'age': BrickVariable.number(
               description: 'the age',
               defaultValue: 42,
+              prompt: 'How old are you?',
             ),
             'isDeveloper': BrickVariable.boolean(
               description: 'whether you are a developer',
               defaultValue: true,
+              prompt: 'Are you a developer?',
             ),
           },
         );
@@ -91,14 +96,17 @@ vars:
     type: string
     description: the name
     default: Dash
+    prompt: What is your name?
   age:
     type: number
     description: the age
     default: 42
+    prompt: How old are you?
   isDeveloper:
     type: boolean
     description: whether you are a developer
     default: true
+    prompt: Are you a developer?
           ''';
 
         final brickYaml = checkedYamlDecode(
@@ -116,16 +124,19 @@ vars:
               type: BrickVariableType.string,
               description: 'the name',
               defaultValue: 'Dash',
+              prompt: 'What is your name?',
             ),
             isBrickVariable(
               type: BrickVariableType.number,
               description: 'the age',
               defaultValue: 42,
+              prompt: 'How old are you?',
             ),
             isBrickVariable(
               type: BrickVariableType.boolean,
               description: 'whether you are a developer',
               defaultValue: true,
+              prompt: 'Are you a developer?',
             ),
           ]),
         );

--- a/packages/mason/test/src/brick_yaml_test.dart
+++ b/packages/mason/test/src/brick_yaml_test.dart
@@ -1,7 +1,19 @@
 // ignore_for_file: prefer_const_constructors
 
+import 'package:checked_yaml/checked_yaml.dart';
 import 'package:mason/mason.dart';
 import 'package:test/test.dart';
+
+Matcher isBrickVariable({
+  required BrickVariableType type,
+  String? description,
+  dynamic defaultValue,
+}) {
+  return isA<BrickVariable>()
+      .having((v) => v.type, 'type', type)
+      .having((v) => v.description, 'description', description)
+      .having((v) => v.defaultValue, 'default', defaultValue);
+}
 
 void main() {
   group('BrickYaml', () {
@@ -14,6 +26,109 @@ void main() {
           path: '.',
         );
         expect(BrickYaml.fromJson(instance.toJson()), equals(instance));
+      });
+
+      test('can be (de)serialized correctly with vars', () {
+        final instance = BrickYaml(
+          name: 'A',
+          description: 'descriptionA',
+          version: '1.0.0',
+          // ignore: prefer_const_literals_to_create_immutables
+          vars: {
+            'name': BrickVariable.string(
+              description: 'the name',
+              defaultValue: 'Dash',
+            ),
+            'age': BrickVariable.number(
+              description: 'the age',
+              defaultValue: 42,
+            ),
+            'isDeveloper': BrickVariable.boolean(
+              description: 'whether you are a developer',
+              defaultValue: true,
+            ),
+          },
+        );
+        expect(BrickYaml.fromJson(instance.toJson()), equals(instance));
+      });
+
+      test('supports simple json format', () {
+        const content = '''
+name: A
+description: descriptionA
+version: '1.0.0'
+vars:
+  - name
+  - age
+  - isDeveloper
+          ''';
+
+        final brickYaml = checkedYamlDecode(
+          content,
+          (v) => BrickYaml.fromJson(v!),
+        );
+        expect(brickYaml.name, equals('A'));
+        expect(brickYaml.description, equals('descriptionA'));
+        expect(brickYaml.version, equals('1.0.0'));
+        expect(brickYaml.vars.keys, equals(['name', 'age', 'isDeveloper']));
+        expect(
+          brickYaml.vars.values,
+          equals([
+            isBrickVariable(type: BrickVariableType.string),
+            isBrickVariable(type: BrickVariableType.string),
+            isBrickVariable(type: BrickVariableType.string),
+          ]),
+        );
+      });
+
+      test('supports complex json format', () {
+        const content = '''
+name: A
+description: descriptionA
+version: '1.0.0'
+vars:
+  name:
+    type: string
+    description: the name
+    default: Dash
+  age:
+    type: number
+    description: the age
+    default: 42
+  isDeveloper:
+    type: boolean
+    description: whether you are a developer
+    default: true
+          ''';
+
+        final brickYaml = checkedYamlDecode(
+          content,
+          (v) => BrickYaml.fromJson(v!),
+        );
+        expect(brickYaml.name, equals('A'));
+        expect(brickYaml.description, equals('descriptionA'));
+        expect(brickYaml.version, equals('1.0.0'));
+        expect(brickYaml.vars.keys, equals(['name', 'age', 'isDeveloper']));
+        expect(
+          brickYaml.vars.values,
+          equals([
+            isBrickVariable(
+              type: BrickVariableType.string,
+              description: 'the name',
+              defaultValue: 'Dash',
+            ),
+            isBrickVariable(
+              type: BrickVariableType.number,
+              description: 'the age',
+              defaultValue: 42,
+            ),
+            isBrickVariable(
+              type: BrickVariableType.boolean,
+              description: 'whether you are a developer',
+              defaultValue: true,
+            ),
+          ]),
+        );
       });
 
       test('can be (de)serialized correctly without path', () {

--- a/packages/mason/test/src/generator_test.dart
+++ b/packages/mason/test/src/generator_test.dart
@@ -46,7 +46,7 @@ void main() {
           description: 'A Simple Hello World Template',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'hello_world', 'brick.yaml'),
-          vars: const ['name'],
+          vars: const {'name': BrickVariable.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -75,7 +75,7 @@ void main() {
           description: 'A Todos Template',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'todos', 'brick.yaml'),
-          vars: const ['todos'],
+          vars: const {'todos': BrickVariable.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -104,7 +104,7 @@ void main() {
           description: 'A Hooks Example Template',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'hooks', 'brick.yaml'),
-          vars: const ['name'],
+          vars: const {'name': BrickVariable.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -142,7 +142,7 @@ void main() {
           description: 'A Simple Hello World Template',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'hello_world', 'brick.yaml'),
-          vars: const ['name'],
+          vars: const {'name': BrickVariable.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -194,7 +194,7 @@ void main() {
           description: 'A Simple Hello World Template',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'hello_world', 'brick.yaml'),
-          vars: const ['name'],
+          vars: const {'name': BrickVariable.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -246,7 +246,7 @@ void main() {
           description: 'A Simple Hello World Template',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'hello_world', 'brick.yaml'),
-          vars: const ['name'],
+          vars: const {'name': BrickVariable.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -307,7 +307,7 @@ void main() {
           description: 'A Simple Hello World Template',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'hello_world', 'brick.yaml'),
-          vars: const ['name'],
+          vars: const {'name': BrickVariable.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -456,7 +456,7 @@ void main() {
           description: 'Create an app_icon file from a URL',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'app_icon', 'brick.yaml'),
-          vars: const ['url'],
+          vars: const {'url': BrickVariable.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -476,7 +476,7 @@ void main() {
           description: 'Create an app_icon file from a URL',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'app_icon', 'brick.yaml'),
-          vars: const ['url'],
+          vars: const {'url': BrickVariable.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();

--- a/packages/mason/test/src/generator_test.dart
+++ b/packages/mason/test/src/generator_test.dart
@@ -506,6 +506,33 @@ void main() {
         expect(fileCount, equals(1));
         expect(file.existsSync(), isTrue);
       });
+
+      test('generates bio', () async {
+        final brickYaml = BrickYaml(
+          name: 'bio',
+          description: 'A Bio Template',
+          version: '1.0.0',
+          path: path.join('..', '..', 'bricks', 'bio', 'brick.yaml'),
+          vars: const {
+            'name': BrickVariable.string(),
+            'age': BrickVariable.number(),
+            'isDeveloper': BrickVariable.boolean(),
+          },
+        );
+        final generator = await MasonGenerator.fromBrickYaml(brickYaml);
+        final tempDir = Directory.systemTemp.createTempSync();
+        final fileCount = await generator.generate(
+          DirectoryGeneratorTarget(tempDir),
+          vars: <String, dynamic>{
+            'name': 'Dash',
+            'age': 42,
+            'isDeveloper': true,
+          },
+        );
+        final file = File(path.join(tempDir.path, 'ABOUT.md'));
+        expect(fileCount, equals(1));
+        expect(file.existsSync(), isTrue);
+      });
     });
 
     group('compareTo', () {

--- a/packages/mason/test/src/generator_test.dart
+++ b/packages/mason/test/src/generator_test.dart
@@ -46,7 +46,7 @@ void main() {
           description: 'A Simple Hello World Template',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'hello_world', 'brick.yaml'),
-          vars: const {'name': BrickVariable.string()},
+          vars: const {'name': BrickVariableProperties.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -75,7 +75,7 @@ void main() {
           description: 'A Todos Template',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'todos', 'brick.yaml'),
-          vars: const {'todos': BrickVariable.string()},
+          vars: const {'todos': BrickVariableProperties.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -104,7 +104,7 @@ void main() {
           description: 'A Hooks Example Template',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'hooks', 'brick.yaml'),
-          vars: const {'name': BrickVariable.string()},
+          vars: const {'name': BrickVariableProperties.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -142,7 +142,7 @@ void main() {
           description: 'A Simple Hello World Template',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'hello_world', 'brick.yaml'),
-          vars: const {'name': BrickVariable.string()},
+          vars: const {'name': BrickVariableProperties.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -194,7 +194,7 @@ void main() {
           description: 'A Simple Hello World Template',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'hello_world', 'brick.yaml'),
-          vars: const {'name': BrickVariable.string()},
+          vars: const {'name': BrickVariableProperties.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -246,7 +246,7 @@ void main() {
           description: 'A Simple Hello World Template',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'hello_world', 'brick.yaml'),
-          vars: const {'name': BrickVariable.string()},
+          vars: const {'name': BrickVariableProperties.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -307,7 +307,7 @@ void main() {
           description: 'A Simple Hello World Template',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'hello_world', 'brick.yaml'),
-          vars: const {'name': BrickVariable.string()},
+          vars: const {'name': BrickVariableProperties.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -456,7 +456,7 @@ void main() {
           description: 'Create an app_icon file from a URL',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'app_icon', 'brick.yaml'),
-          vars: const {'url': BrickVariable.string()},
+          vars: const {'url': BrickVariableProperties.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -476,7 +476,7 @@ void main() {
           description: 'Create an app_icon file from a URL',
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'app_icon', 'brick.yaml'),
-          vars: const {'url': BrickVariable.string()},
+          vars: const {'url': BrickVariableProperties.string()},
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
@@ -514,9 +514,9 @@ void main() {
           version: '1.0.0',
           path: path.join('..', '..', 'bricks', 'bio', 'brick.yaml'),
           vars: const {
-            'name': BrickVariable.string(),
-            'age': BrickVariable.number(),
-            'isDeveloper': BrickVariable.boolean(),
+            'name': BrickVariableProperties.string(),
+            'age': BrickVariableProperties.number(),
+            'isDeveloper': BrickVariableProperties.boolean(),
           },
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);

--- a/packages/mason/test/src/mason_bundle_test.dart
+++ b/packages/mason/test/src/mason_bundle_test.dart
@@ -18,7 +18,7 @@ void main() {
 
   group('MasonBundle', () {
     test('can be (de)serialized', () {
-      final instance = MasonBundle('name', 'description', [], [], []);
+      final instance = MasonBundle('name', 'description', {}, [], []);
       expect(
         MasonBundle.fromJson(instance.toJson()),
         isA<MasonBundle>()

--- a/packages/mason/test/src/mason_bundle_test.dart
+++ b/packages/mason/test/src/mason_bundle_test.dart
@@ -40,17 +40,17 @@ void main() {
         'name',
         'description',
         {
-          'name': BrickVariable.string(
+          'name': BrickVariableProperties.string(
             defaultValue: 'Dash',
             description: 'Your name',
             prompt: 'What is your name?',
           ),
-          'age': BrickVariable.number(
+          'age': BrickVariableProperties.number(
             defaultValue: 42,
             description: 'Your age',
             prompt: 'How old are you?',
           ),
-          'isDeveloper': BrickVariable.boolean(
+          'isDeveloper': BrickVariableProperties.boolean(
             defaultValue: false,
             description: 'If you are a dev',
             prompt: 'Are you a developer?',
@@ -60,17 +60,17 @@ void main() {
         [],
       );
       final hasCorrectVars = equals({
-        'name': isA<BrickVariable>()
+        'name': isA<BrickVariableProperties>()
             .having((v) => v.type, 'type', BrickVariableType.string)
             .having((v) => v.defaultValue, 'defaultValue', 'Dash')
             .having((v) => v.description, 'description', 'Your name')
             .having((v) => v.prompt, 'prompt', 'What is your name?'),
-        'age': isA<BrickVariable>()
+        'age': isA<BrickVariableProperties>()
             .having((v) => v.type, 'type', BrickVariableType.number)
             .having((v) => v.defaultValue, 'defaultValue', 42)
             .having((v) => v.description, 'description', 'Your age')
             .having((v) => v.prompt, 'prompt', 'How old are you?'),
-        'isDeveloper': isA<BrickVariable>()
+        'isDeveloper': isA<BrickVariableProperties>()
             .having((v) => v.type, 'type', BrickVariableType.boolean)
             .having((v) => v.defaultValue, 'defaultValue', false)
             .having((v) => v.description, 'description', 'If you are a dev')

--- a/packages/mason/test/src/mason_bundle_test.dart
+++ b/packages/mason/test/src/mason_bundle_test.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: prefer_const_constructors
+import 'package:mason/mason.dart';
 import 'package:mason/src/mason_bundle.dart';
 import 'package:test/test.dart';
 
@@ -24,6 +25,62 @@ void main() {
         isA<MasonBundle>()
             .having((file) => file.name, 'name', instance.name)
             .having((file) => file.vars, 'vars', instance.vars)
+            .having((file) => file.files, 'files', instance.files)
+            .having((file) => file.hooks, 'hooks', instance.hooks)
+            .having(
+              (file) => file.description,
+              'description',
+              instance.description,
+            ),
+      );
+    });
+
+    test('can be (de)serialized w/vars', () {
+      final instance = MasonBundle(
+        'name',
+        'description',
+        {
+          'name': BrickVariable.string(
+            defaultValue: 'Dash',
+            description: 'Your name',
+            prompt: 'What is your name?',
+          ),
+          'age': BrickVariable.number(
+            defaultValue: 42,
+            description: 'Your age',
+            prompt: 'How old are you?',
+          ),
+          'isDeveloper': BrickVariable.boolean(
+            defaultValue: false,
+            description: 'If you are a dev',
+            prompt: 'Are you a developer?',
+          ),
+        },
+        [],
+        [],
+      );
+      final hasCorrectVars = equals({
+        'name': isA<BrickVariable>()
+            .having((v) => v.type, 'type', BrickVariableType.string)
+            .having((v) => v.defaultValue, 'defaultValue', 'Dash')
+            .having((v) => v.description, 'description', 'Your name')
+            .having((v) => v.prompt, 'prompt', 'What is your name?'),
+        'age': isA<BrickVariable>()
+            .having((v) => v.type, 'type', BrickVariableType.number)
+            .having((v) => v.defaultValue, 'defaultValue', 42)
+            .having((v) => v.description, 'description', 'Your age')
+            .having((v) => v.prompt, 'prompt', 'How old are you?'),
+        'isDeveloper': isA<BrickVariable>()
+            .having((v) => v.type, 'type', BrickVariableType.boolean)
+            .having((v) => v.defaultValue, 'defaultValue', false)
+            .having((v) => v.description, 'description', 'If you are a dev')
+            .having((v) => v.prompt, 'prompt', 'Are you a developer?'),
+      });
+      expect(
+        MasonBundle.fromJson(instance.toJson()),
+        isA<MasonBundle>()
+            .having((file) => file.name, 'name', instance.name)
+            .having((file) => file.vars, 'vars', hasCorrectVars)
             .having((file) => file.files, 'files', instance.files)
             .having((file) => file.hooks, 'hooks', instance.hooks)
             .having(

--- a/packages/mason_cli/example/mason.yaml
+++ b/packages/mason_cli/example/mason.yaml
@@ -1,6 +1,8 @@
 bricks:
   app_icon:
     path: ../../../bricks/app_icon
+  bio:
+    path: ../../../bricks/bio
   documentation:
     path: ../../../bricks/documentation
   greeting:

--- a/packages/mason_cli/lib/src/commands/make.dart
+++ b/packages/mason_cli/lib/src/commands/make.dart
@@ -50,11 +50,11 @@ class _MakeCommand extends MasonCommand {
       ..addSeparator('${'-' * 79}\n');
 
     for (final entry in _brick.vars.entries) {
-      final variableName = entry.key;
-      final variable = entry.value;
+      final variable = entry.key;
+      final properties = entry.value;
       argParser.addOption(
-        variableName,
-        help: variable.toHelp(),
+        variable,
+        help: properties.toHelp(),
       );
     }
   }
@@ -99,35 +99,35 @@ class _MakeCommand extends MasonCommand {
       }
 
       for (final entry in _brick.vars.entries) {
-        final variableName = entry.key;
-        final variable = entry.value;
-        if (vars.containsKey(variableName)) continue;
-        final arg = results[variableName] as String?;
+        final variable = entry.key;
+        final properties = entry.value;
+        if (vars.containsKey(variable)) continue;
+        final arg = results[variable] as String?;
         if (arg != null) {
-          vars.addAll(<String, dynamic>{variableName: _maybeDecode(arg)});
+          vars.addAll(<String, dynamic>{variable: _maybeDecode(arg)});
         } else {
           final prompt =
-              '''${styleBold.wrap(lightGreen.wrap('?'))} ${variable.prompt ?? variableName}''';
+              '''${styleBold.wrap(lightGreen.wrap('?'))} ${properties.prompt ?? variable}''';
           late final dynamic response;
-          switch (variable.type) {
+          switch (properties.type) {
             case BrickVariableType.string:
               response = _maybeDecode(
-                logger.prompt(prompt, defaultValue: variable.defaultValue),
+                logger.prompt(prompt, defaultValue: properties.defaultValue),
               );
               break;
             case BrickVariableType.number:
               response = logger.prompt(
                 prompt,
-                defaultValue: variable.defaultValue,
+                defaultValue: properties.defaultValue,
               );
               break;
             case BrickVariableType.boolean:
               response = logger.confirm(
                 prompt,
-                defaultValue: variable.defaultValue as bool? ?? false,
+                defaultValue: properties.defaultValue as bool? ?? false,
               );
           }
-          vars.addAll(<String, dynamic>{variableName: response});
+          vars.addAll(<String, dynamic>{variable: response});
         }
       }
 
@@ -192,7 +192,7 @@ extension on BrickVariableType {
   }
 }
 
-extension on BrickVariable {
+extension on BrickVariableProperties {
   String toHelp() {
     final _type = '<${type.name}>';
     final _defaultValue =

--- a/packages/mason_cli/lib/src/commands/make.dart
+++ b/packages/mason_cli/lib/src/commands/make.dart
@@ -45,9 +45,17 @@ class MakeCommand extends MasonCommand {
 
 class _MakeCommand extends MasonCommand {
   _MakeCommand(this._brick, {Logger? logger}) : super(logger: logger) {
-    argParser.addOptions();
-    for (final arg in _brick.vars.keys) {
-      argParser.addOption(arg);
+    argParser
+      ..addOptions()
+      ..addSeparator('${'-' * 79}\n');
+
+    for (final entry in _brick.vars.entries) {
+      final variableName = entry.key;
+      final variable = entry.value;
+      argParser.addOption(
+        variableName,
+        help: variable.toHelp(),
+      );
     }
   }
 
@@ -168,6 +176,34 @@ class _MakeCommand extends MasonCommand {
     } catch (_) {
       return value;
     }
+  }
+}
+
+extension on BrickVariableType {
+  String get name {
+    switch (this) {
+      case BrickVariableType.number:
+        return 'number';
+      case BrickVariableType.string:
+        return 'string';
+      case BrickVariableType.boolean:
+        return 'boolean';
+    }
+  }
+}
+
+extension on BrickVariable {
+  String toHelp() {
+    final _type = '<${type.name}>';
+    final _defaultValue =
+        type == BrickVariableType.string ? '"$defaultValue"' : '$defaultValue';
+    final defaultsTo = '(defaults to $_defaultValue)';
+    if (description != null && defaultValue != null) {
+      return '$description $_type\n$defaultsTo';
+    }
+    if (description != null) return '$description $_type';
+    if (defaultValue != null) return '$_type\n$defaultsTo';
+    return _type;
   }
 }
 

--- a/packages/mason_cli/lib/src/commands/make.dart
+++ b/packages/mason_cli/lib/src/commands/make.dart
@@ -46,7 +46,7 @@ class MakeCommand extends MasonCommand {
 class _MakeCommand extends MasonCommand {
   _MakeCommand(this._brick, {Logger? logger}) : super(logger: logger) {
     argParser.addOptions();
-    for (final arg in _brick.vars) {
+    for (final arg in _brick.vars.keys) {
       argParser.addOption(arg);
     }
   }
@@ -90,7 +90,7 @@ class _MakeCommand extends MasonCommand {
         return ExitCode.usage.code;
       }
 
-      for (final variable in _brick.vars) {
+      for (final variable in _brick.vars.keys) {
         if (vars.containsKey(variable)) continue;
         final arg = results[variable] as String?;
         if (arg != null) {

--- a/packages/mason_cli/pubspec.yaml
+++ b/packages/mason_cli/pubspec.yaml
@@ -29,6 +29,8 @@ dev_dependencies:
 dependency_overrides:
   mason:
     path: ../mason
+  mason_logger:
+    path: ../mason_logger
 
 executables:
   mason:

--- a/packages/mason_cli/test/commands/bundle_test.dart
+++ b/packages/mason_cli/test/commands/bundle_test.dart
@@ -45,7 +45,7 @@ void main() {
       );
       final actual = file.readAsStringSync();
       const expected =
-          '''{"files":[{"path":"GREETINGS.md","data":"SGkge3tuYW1lfX0h","type":"text"}],"hooks":[],"name":"greeting","description":"A Simple Greeting Template","vars":["name"]}''';
+          '''{"files":[{"path":"GREETINGS.md","data":"SGkge3tuYW1lfX0h","type":"text"}],"hooks":[],"name":"greeting","description":"A Simple Greeting Template","vars":{"name":{"type":"string"}}}''';
       expect(actual, equals(expected));
       verify(() => logger.progress('Bundling greeting')).called(1);
       verify(
@@ -95,7 +95,7 @@ void main() {
       expect(
         actual,
         contains(
-          '''"name":"hooks","description":"A Hooks Example Template","vars":["name"]''',
+          '''"name":"hooks","description":"A Hooks Example Template","vars":{"name":{"type":"string"}}''',
         ),
       );
       verify(() => logger.progress('Bundling hooks')).called(1);
@@ -139,7 +139,7 @@ void main() {
       expect(
         actual,
         contains(
-          '''final greetingBundle = MasonBundle.fromJson(<String, dynamic>{"files":[{"path":"GREETINGS.md","data":"SGkge3tuYW1lfX0h","type":"text"}],"hooks":[],"name":"greeting","description":"A Simple Greeting Template","vars":["name"]});''',
+          '''final greetingBundle = MasonBundle.fromJson(<String, dynamic>{"files":[{"path":"GREETINGS.md","data":"SGkge3tuYW1lfX0h","type":"text"}],"hooks":[],"name":"greeting","description":"A Simple Greeting Template","vars":{"name":{"type":"string"}}});''',
         ),
       );
       verify(() => logger.progress('Bundling greeting')).called(1);
@@ -205,7 +205,7 @@ void main() {
       expect(
         actual,
         contains(
-          '''"name":"hooks","description":"A Hooks Example Template","vars":["name"]''',
+          '''"name":"hooks","description":"A Hooks Example Template","vars":{"name":{"type":"string"}}''',
         ),
       );
       verify(() => logger.progress('Bundling hooks')).called(1);

--- a/packages/mason_cli/test/commands/make_test.dart
+++ b/packages/mason_cli/test/commands/make_test.dart
@@ -188,7 +188,7 @@ bricks:
     );
 
     test(
-      '<subcommand> --help shows correct help information',
+      '<subcommand> --help shows correct help information (greeting)',
       overridePrint(() async {
         const expectedPrintLogs = <String>[
           'A Simple Greeting Template\n'
@@ -206,15 +206,49 @@ bricks:
               '''          [prompt] (default)    Always prompt the user for each file conflict.\n'''
               '          [skip]                Always skip conflicting files.\n'
               '\n'
-              '    --name                      \n'
+              '''-------------------------------------------------------------------------------\n'''
+              '\n'
+              '    --name                      <string>\n'
               '\n'
               'Run "mason help" to see global options.'
         ];
-        final testDir = Directory(
-          path.join(Directory.current.path, 'greeting'),
-        )..createSync(recursive: true);
-        Directory.current = testDir.path;
         final result = await commandRunner.run(['make', 'greeting', '--help']);
+        expect(result, equals(ExitCode.success.code));
+        expect(printLogs, equals(expectedPrintLogs));
+      }),
+    );
+
+    test(
+      '<subcommand> --help shows correct help information (bio)',
+      overridePrint(() async {
+        const expectedPrintLogs = <String>[
+          'A Bio Template\n'
+              '\n'
+              'Usage: mason make bio [arguments]\n'
+              '-h, --help                      Print this usage information.\n'
+              '    --no-hooks                  skips running hooks\n'
+              '''-c, --config-path               Path to config json file containing variables.\n'''
+              '''-o, --output-dir                Directory where to output the generated code.\n'''
+              '                                (defaults to ".")\n'
+              '''    --on-conflict               File conflict resolution strategy.\n'''
+              '\n'
+              '''          [append]              Always append conflicting files.\n'''
+              '''          [overwrite]           Always overwrite conflicting files.\n'''
+              '''          [prompt] (default)    Always prompt the user for each file conflict.\n'''
+              '          [skip]                Always skip conflicting files.\n'
+              '\n'
+              '''-------------------------------------------------------------------------------\n'''
+              '\n'
+              '''    --name                      Name of the current user <string>\n'''
+              '                                (defaults to "Dash")\n'
+              '''    --age                       Age of the current user <number>\n'''
+              '                                (defaults to 42)\n'
+              '''    --isDeveloper               If the current user is a developer <boolean>\n'''
+              '                                (defaults to false)\n'
+              '\n'
+              'Run "mason help" to see global options.'
+        ];
+        final result = await commandRunner.run(['make', 'bio', '--help']);
         expect(result, equals(ExitCode.success.code));
         expect(printLogs, equals(expectedPrintLogs));
       }),

--- a/packages/mason_cli/test/fixtures/make/bio/ABOUT.md
+++ b/packages/mason_cli/test/fixtures/make/bio/ABOUT.md
@@ -1,0 +1,3 @@
+# About
+
+Hello, my name is Dash! I am 42 years old and I am not a developer.

--- a/packages/mason_cli/test/fixtures/make/mason.yaml
+++ b/packages/mason_cli/test/fixtures/make/mason.yaml
@@ -1,6 +1,8 @@
 bricks:
   app_icon:
     path: ../../../../../bricks/app_icon
+  bio:
+    path: ../../../../../bricks/bio
   documentation:
     path: ../../../../../bricks/documentation
   hello_world:

--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -146,8 +146,58 @@ class Logger {
   void success(String? message) => _stdout.writeln(lightGreen.wrap(message));
 
   /// Prompts user and returns response.
-  String prompt(String? message) {
-    _stdout.write(message);
-    return _stdin.readLineSync() ?? '';
+  String prompt(String? message, {Object? defaultValue}) {
+    final hasDefault = defaultValue != null && '$defaultValue'.isNotEmpty;
+    final _defaultValue = hasDefault ? '$defaultValue' : '';
+    final suffix = hasDefault ? ' (${darkGray.wrap(_defaultValue)})' : '';
+    final _message = '$message$suffix ';
+    _stdout.write(_message);
+    final input = _stdin.readLineSync()?.trim();
+    final response = input == null || input.isEmpty ? _defaultValue : input;
+    _stdout.writeln(
+      '\x1b[A\u001B[2K$_message${lightCyan.wrap(styleBold.wrap(response))}',
+    );
+    return response;
+  }
+
+  /// Prompts user with a yes/no question.
+  bool confirm(String? message, {bool defaultValue = false}) {
+    final suffix = ' (${darkGray.wrap(defaultValue.toYesNo())})';
+    final _message = '$message$suffix ';
+    _stdout.write(_message);
+    final input = _stdin.readLineSync()?.trim();
+    final response = input == null || input.isEmpty
+        ? defaultValue
+        : input.toBoolean() ?? defaultValue;
+    _stdout.writeln(
+      '''\x1b[A\u001B[2K$_message${lightCyan.wrap(styleBold.wrap(response ? 'Yes' : 'No'))}''',
+    );
+    return response;
+  }
+}
+
+extension on bool {
+  String toYesNo() {
+    return this == true ? 'Y/n' : 'y/N';
+  }
+}
+
+extension on String {
+  bool? toBoolean() {
+    switch (toLowerCase()) {
+      case 'y':
+      case 'yea':
+      case 'yeah':
+      case 'yep':
+      case 'yes':
+      case 'yup':
+        return true;
+      case 'n':
+      case 'no':
+      case 'nope':
+        return false;
+      default:
+        return null;
+    }
   }
 }

--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -149,28 +149,28 @@ class Logger {
   String prompt(String? message, {Object? defaultValue}) {
     final hasDefault = defaultValue != null && '$defaultValue'.isNotEmpty;
     final _defaultValue = hasDefault ? '$defaultValue' : '';
-    final suffix = hasDefault ? ' (${darkGray.wrap(_defaultValue)})' : '';
-    final _message = '$message$suffix ';
+    final suffix = hasDefault ? ' ${darkGray.wrap('($_defaultValue)')} ' : '';
+    final _message = '$message$suffix';
     _stdout.write(_message);
     final input = _stdin.readLineSync()?.trim();
     final response = input == null || input.isEmpty ? _defaultValue : input;
     _stdout.writeln(
-      '\x1b[A\u001B[2K$_message${lightCyan.wrap(styleBold.wrap(response))}',
+      '\x1b[A\u001B[2K$_message${styleDim.wrap(lightCyan.wrap(response))}',
     );
     return response;
   }
 
   /// Prompts user with a yes/no question.
   bool confirm(String? message, {bool defaultValue = false}) {
-    final suffix = ' (${darkGray.wrap(defaultValue.toYesNo())})';
-    final _message = '$message$suffix ';
+    final suffix = ' ${darkGray.wrap('(${defaultValue.toYesNo()})')} ';
+    final _message = '$message$suffix';
     _stdout.write(_message);
     final input = _stdin.readLineSync()?.trim();
     final response = input == null || input.isEmpty
         ? defaultValue
         : input.toBoolean() ?? defaultValue;
     _stdout.writeln(
-      '''\x1b[A\u001B[2K$_message${lightCyan.wrap(styleBold.wrap(response ? 'Yes' : 'No'))}''',
+      '''\x1b[A\u001B[2K$_message${styleDim.wrap(lightCyan.wrap(response ? 'Yes' : 'No'))}''',
     );
     return response;
   }

--- a/packages/mason_logger/test/src/mason_logger_test.dart
+++ b/packages/mason_logger/test/src/mason_logger_test.dart
@@ -155,12 +155,151 @@ void main() {
       test('writes line to stdout and reads line from stdin', () {
         StdioOverrides.runZoned(
           () {
-            const prompt = 'test message';
+            const message = 'test message';
             const response = 'test response';
+            final promptWithResponse =
+                '''\x1b[A\u001B[2K$message${styleDim.wrap(lightCyan.wrap(response))}''';
             when(() => stdin.readLineSync()).thenReturn(response);
-            final actual = Logger().prompt(prompt);
+            final actual = Logger().prompt(message);
+            expect(actual, equals(response));
+            verify(() => stdout.write(message)).called(1);
+            verify(() => stdout.writeln(promptWithResponse)).called(1);
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
+
+      test('writes line to stdout and reads line from stdin with default', () {
+        StdioOverrides.runZoned(
+          () {
+            const defaultValue = 'Dash';
+            const message = 'test message';
+            const response = 'test response';
+            final prompt = '$message ${darkGray.wrap('($defaultValue)')} ';
+            final promptWithResponse =
+                '''\x1b[A\u001B[2K$prompt${styleDim.wrap(lightCyan.wrap(response))}''';
+            when(() => stdin.readLineSync()).thenReturn(response);
+            final actual = Logger().prompt(message, defaultValue: defaultValue);
             expect(actual, equals(response));
             verify(() => stdout.write(prompt)).called(1);
+            verify(() => stdout.writeln(promptWithResponse)).called(1);
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
+    });
+
+    group('.confirm', () {
+      test('writes line to stdout and reads line from stdin (default no)', () {
+        StdioOverrides.runZoned(
+          () {
+            const message = 'test message';
+            final prompt = 'test message ${darkGray.wrap('(y/N)')} ';
+            final promptWithResponse =
+                '''\x1b[A\u001B[2K$prompt${styleDim.wrap(lightCyan.wrap('No'))}''';
+            when(() => stdin.readLineSync()).thenReturn('');
+            final actual = Logger().confirm(message);
+            expect(actual, isFalse);
+            verify(() => stdout.write(prompt)).called(1);
+            verify(() => stdout.writeln(promptWithResponse)).called(1);
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
+
+      test('writes line to stdout and reads line from stdin (default yes)', () {
+        StdioOverrides.runZoned(
+          () {
+            const message = 'test message';
+            final prompt = 'test message ${darkGray.wrap('(Y/n)')} ';
+            final promptWithResponse =
+                '''\x1b[A\u001B[2K$prompt${styleDim.wrap(lightCyan.wrap('Yes'))}''';
+            when(() => stdin.readLineSync()).thenReturn('y');
+            final actual = Logger().confirm(message, defaultValue: true);
+            expect(actual, isTrue);
+            verify(() => stdout.write(prompt)).called(1);
+            verify(() => stdout.writeln(promptWithResponse)).called(1);
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
+
+      test('handles all versions of yes correctly', () {
+        StdioOverrides.runZoned(
+          () {
+            const message = 'test message';
+            final prompt = 'test message ${darkGray.wrap('(y/N)')} ';
+            const yesWords = ['y', 'Y', 'Yes', 'yes', 'yeah', 'yea', 'yup'];
+            for (final word in yesWords) {
+              final promptWithResponse =
+                  '''\x1b[A\u001B[2K$prompt${styleDim.wrap(lightCyan.wrap('Yes'))}''';
+              when(() => stdin.readLineSync()).thenReturn(word);
+              final actual = Logger().confirm(message);
+              expect(actual, isTrue);
+              verify(() => stdout.write(prompt)).called(1);
+              verify(() => stdout.writeln(promptWithResponse)).called(1);
+            }
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
+
+      test('handles all versions of no correctly', () {
+        StdioOverrides.runZoned(
+          () {
+            const message = 'test message';
+            final prompt = 'test message ${darkGray.wrap('(y/N)')} ';
+            const noWords = ['n', 'N', 'No', 'no', 'nope', 'Nope', 'nopE'];
+            for (final word in noWords) {
+              final promptWithResponse =
+                  '''\x1b[A\u001B[2K$prompt${styleDim.wrap(lightCyan.wrap('No'))}''';
+              when(() => stdin.readLineSync()).thenReturn(word);
+              final actual = Logger().confirm(message);
+              expect(actual, isFalse);
+              verify(() => stdout.write(prompt)).called(1);
+              verify(() => stdout.writeln(promptWithResponse)).called(1);
+            }
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
+
+      test('returns default when response is neither yes/no (default no)', () {
+        StdioOverrides.runZoned(
+          () {
+            const message = 'test message';
+            final prompt = 'test message ${darkGray.wrap('(y/N)')} ';
+            final promptWithResponse =
+                '''\x1b[A\u001B[2K$prompt${styleDim.wrap(lightCyan.wrap('No'))}''';
+            when(() => stdin.readLineSync()).thenReturn('maybe');
+            final actual = Logger().confirm(message);
+            expect(actual, isFalse);
+            verify(() => stdout.write(prompt)).called(1);
+            verify(() => stdout.writeln(promptWithResponse)).called(1);
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
+
+      test('returns default when response is neither yes/no (default yes)', () {
+        StdioOverrides.runZoned(
+          () {
+            const message = 'test message';
+            final prompt = 'test message ${darkGray.wrap('(Y/n)')} ';
+            final promptWithResponse =
+                '''\x1b[A\u001B[2K$prompt${styleDim.wrap(lightCyan.wrap('Yes'))}''';
+            when(() => stdin.readLineSync()).thenReturn('maybe');
+            final actual = Logger().confirm(message, defaultValue: true);
+            expect(actual, isTrue);
+            verify(() => stdout.write(prompt)).called(1);
+            verify(() => stdout.writeln(promptWithResponse)).called(1);
           },
           stdout: () => stdout,
           stdin: () => stdin,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

<!--- Describe your changes in detail -->

Currently, it's not possible to provide defaults or metadata about the variables that a brick requires:

```yaml
name: bio
description: A Bio Template
version: '1.0.0'
vars:
  - name
  - age
  - isDeveloper
```

This pull request updates the core mason library to allow developers to specify the type, description, default value, and prompt for each variable.

```yaml
name: bio
description: A Bio Template
version: 1.0.0
vars:
  name:
    type: string
    description: Name of the current user
    default: Dash
    prompt: What is your name?
  age:
    type: number
    description: Age of the current user
    default: 42
    prompt: How old are you?
  isDeveloper:
    type: boolean
    description: If the current user is a developer
    default: false
    prompt: Are you a developer?
```

The changes are backward compatible so previous brick.yaml files will still work. For example, the original template would be interpreted as:

```yaml
name: bio
description: A Bio Template
version: '1.0.0'
vars:
  name:
    type: string
  age:
    type: string
  isDeveloper:
    type: string
```

In addition, the `mason make <brick> --help` command can provide more useful information regarding the variables:

```sh
$ mason make bio --help
A Bio Template

Usage: mason make bio [arguments]
-h, --help                      Print this usage information.
    --no-hooks                  skips running hooks
-c, --config-path               Path to config json file containing variables.
-o, --output-dir                Directory where to output the generated code.
                                (defaults to ".")
    --on-conflict               File conflict resolution strategy.

          [append]              Always append conflicting files.
          [overwrite]           Always overwrite conflicting files.
          [prompt] (default)    Always prompt the user for each file conflict.
          [skip]                Always skip conflicting files.

-------------------------------------------------------------------------------

    --name                      Name of the current user <string>
                                (defaults to "Dash")
    --age                       Age of the current user <number>
                                (defaults to 42)
    --isDeveloper               If the current user is a developer <boolean>
                                (defaults to false)

Run "mason help" to see global options.
```

- closes #169
- closes #186
- closes #98

![mason-vars](https://user-images.githubusercontent.com/8855632/149609217-d2c8899e-2457-4a38-8282-85d6d005bcab.png)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
