### PR TITLE
refactor(mason)!: API updates to MasonBundle, MasonGenerator, and DirectoryGeneratorTarget

### DIFF
--- a/packages/mason/lib/src/bundler.dart
+++ b/packages/mason/lib/src/bundler.dart
@@ -35,12 +35,12 @@ MasonBundle createBundle(Directory brick) {
           .toList()
       : <MasonBundledFile>[];
   return MasonBundle(
-    brickYaml.name,
-    brickYaml.description,
-    brickYaml.version,
-    brickYaml.vars,
-    files..sort(_comparePaths),
-    hooks..sort(_comparePaths),
+    name: brickYaml.name,
+    description: brickYaml.description,
+    version: brickYaml.version,
+    vars: brickYaml.vars,
+    files: files..sort(_comparePaths),
+    hooks: hooks..sort(_comparePaths),
   );
 }
 

--- a/packages/mason/lib/src/mason_bundle.dart
+++ b/packages/mason/lib/src/mason_bundle.dart
@@ -34,14 +34,14 @@ class MasonBundledFile {
 @JsonSerializable()
 class MasonBundle {
   /// {@macro mason_bundle}
-  const MasonBundle(
-    this.name,
-    this.description,
-    this.version,
-    this.vars,
-    this.files,
-    this.hooks,
-  );
+  const MasonBundle({
+    required this.name,
+    required this.description,
+    required this.version,
+    this.vars = const <String, BrickVariableProperties>{},
+    this.files = const [],
+    this.hooks = const [],
+  });
 
   /// Converts a [Map<String, dynamic>] into a [MasonBundle] instance.
   factory MasonBundle.fromJson(Map<String, dynamic> json) =>

--- a/packages/mason/lib/src/mason_bundle.g.dart
+++ b/packages/mason/lib/src/mason_bundle.g.dart
@@ -46,17 +46,23 @@ MasonBundle _$MasonBundleFromJson(Map json) => $checkedCreate(
           ],
         );
         final val = MasonBundle(
-          $checkedConvert('name', (v) => v as String),
-          $checkedConvert('description', (v) => v as String),
-          $checkedConvert('version', (v) => v as String),
-          $checkedConvert('vars', (v) => const VarsConverter().fromJson(v)),
-          $checkedConvert(
+          name: $checkedConvert('name', (v) => v as String),
+          description: $checkedConvert('description', (v) => v as String),
+          version: $checkedConvert('version', (v) => v as String),
+          vars: $checkedConvert(
+              'vars',
+              (v) => v == null
+                  ? const <String, BrickVariableProperties>{}
+                  : const VarsConverter().fromJson(v)),
+          files: $checkedConvert(
               'files',
-              (v) => (v as List<dynamic>)
-                  .map((e) => MasonBundledFile.fromJson(
-                      Map<String, dynamic>.from(e as Map)))
-                  .toList()),
-          $checkedConvert(
+              (v) =>
+                  (v as List<dynamic>?)
+                      ?.map((e) => MasonBundledFile.fromJson(
+                          Map<String, dynamic>.from(e as Map)))
+                      .toList() ??
+                  const []),
+          hooks: $checkedConvert(
               'hooks',
               (v) =>
                   (v as List<dynamic>?)

--- a/packages/mason/test/src/generator_test.dart
+++ b/packages/mason/test/src/generator_test.dart
@@ -135,7 +135,9 @@ void main() {
         expect(postGenFile.readAsStringSync(), equals('post_gen: $name'));
       });
 
-      test('constructs an instance multiple times (hello_world)', () async {
+      test(
+          'constructs an instance multiple times '
+          '(identical) (hello_world)', () async {
         const name = 'Dash';
         final brickYaml = BrickYaml(
           name: 'hello_world',
@@ -146,10 +148,12 @@ void main() {
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
+        final logger = MockLogger();
 
         final fileCount1 = await generator.generate(
           DirectoryGeneratorTarget(tempDir),
           vars: <String, dynamic>{'name': name},
+          logger: logger,
         );
         final file1 = File(path.join(tempDir.path, 'HELLO.md'));
         expect(fileCount1, equals(1));
@@ -164,10 +168,15 @@ void main() {
             '_made with 💖 by mason_',
           ),
         );
+        verify(() => logger.delayed(any(that: contains('(new)')))).called(1);
+        verifyNever(
+          () => logger.delayed(any(that: contains('(identical)'))),
+        );
 
         final fileCount2 = await generator.generate(
           DirectoryGeneratorTarget(tempDir),
           vars: <String, dynamic>{'name': name},
+          logger: logger,
         );
         final file2 = File(path.join(tempDir.path, 'HELLO.md'));
         expect(fileCount2, equals(1));
@@ -182,6 +191,10 @@ void main() {
             '_made with 💖 by mason_',
           ),
         );
+        verify(
+          () => logger.delayed(any(that: contains('(identical)'))),
+        ).called(1);
+        verifyNever(() => logger.delayed(any(that: contains('(new)'))));
       });
 
       test(
@@ -198,10 +211,12 @@ void main() {
         );
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
+        final logger = MockLogger();
 
         final fileCount1 = await generator.generate(
           DirectoryGeneratorTarget(tempDir),
           vars: <String, dynamic>{'name': name},
+          logger: logger,
         );
         final file1 = File(path.join(tempDir.path, 'HELLO.md'));
         expect(fileCount1, equals(1));
@@ -216,10 +231,14 @@ void main() {
             '_made with 💖 by mason_',
           ),
         );
+        verify(() => logger.delayed(any(that: contains('(new)')))).called(1);
+        verifyNever(() => logger.delayed(any(that: contains('(skip)'))));
 
         final fileCount2 = await generator.generate(
-          DirectoryGeneratorTarget(tempDir, null, FileConflictResolution.skip),
+          DirectoryGeneratorTarget(tempDir),
           vars: <String, dynamic>{'name': otherName},
+          fileConflictResolution: FileConflictResolution.skip,
+          logger: logger,
         );
         final file2 = File(path.join(tempDir.path, 'HELLO.md'));
         expect(fileCount2, equals(1));
@@ -234,6 +253,8 @@ void main() {
             '_made with 💖 by mason_',
           ),
         );
+        verify(() => logger.delayed(any(that: contains('(skip)')))).called(1);
+        verifyNever(() => logger.delayed(any(that: contains('(new)'))));
       });
 
       test(
@@ -252,8 +273,9 @@ void main() {
         final tempDir = Directory.systemTemp.createTempSync();
         final logger = MockLogger();
         final fileCount1 = await generator.generate(
-          DirectoryGeneratorTarget(tempDir, logger),
+          DirectoryGeneratorTarget(tempDir),
           vars: <String, dynamic>{'name': name},
+          logger: logger,
         );
         final file1 = File(path.join(tempDir.path, 'HELLO.md'));
         expect(fileCount1, equals(1));
@@ -270,12 +292,10 @@ void main() {
         );
 
         final fileCount2 = await generator.generate(
-          DirectoryGeneratorTarget(
-            tempDir,
-            logger,
-            FileConflictResolution.append,
-          ),
+          DirectoryGeneratorTarget(tempDir),
           vars: <String, dynamic>{'name': otherName},
+          fileConflictResolution: FileConflictResolution.append,
+          logger: logger,
         );
         final file2 = File(path.join(tempDir.path, 'HELLO.md'));
         expect(fileCount2, equals(1));
@@ -333,12 +353,10 @@ void main() {
         final logger = MockLogger();
         when(() => logger.prompt(any())).thenReturn('Y');
         final fileCount2 = await generator.generate(
-          DirectoryGeneratorTarget(
-            tempDir,
-            logger,
-            FileConflictResolution.prompt,
-          ),
+          DirectoryGeneratorTarget(tempDir),
           vars: <String, dynamic>{'name': otherName},
+          fileConflictResolution: FileConflictResolution.prompt,
+          logger: logger,
         );
         final file2 = File(path.join(tempDir.path, 'HELLO.md'));
         expect(fileCount2, equals(1));
@@ -420,8 +438,9 @@ void main() {
         final generator = await MasonGenerator.fromBrickYaml(brickYaml);
         final tempDir = Directory.systemTemp.createTempSync();
         final fileCount = await generator.generate(
-          DirectoryGeneratorTarget(tempDir, null, FileConflictResolution.skip),
+          DirectoryGeneratorTarget(tempDir),
           vars: <String, dynamic>{'name': name},
+          fileConflictResolution: FileConflictResolution.skip,
         );
         final file = File(path.join(tempDir.path, 'HELLO.md'));
         expect(fileCount, equals(1));

--- a/packages/mason/test/src/mason_bundle_test.dart
+++ b/packages/mason/test/src/mason_bundle_test.dart
@@ -19,7 +19,14 @@ void main() {
 
   group('MasonBundle', () {
     test('can be (de)serialized', () {
-      final instance = MasonBundle('name', 'description', '1.0.0', {}, [], []);
+      final instance = MasonBundle(
+        name: 'name',
+        description: 'description',
+        version: '1.0.0',
+        vars: {},
+        files: [],
+        hooks: [],
+      );
       expect(
         MasonBundle.fromJson(instance.toJson()),
         isA<MasonBundle>()
@@ -38,10 +45,10 @@ void main() {
 
     test('can be (de)serialized w/vars', () {
       final instance = MasonBundle(
-        'name',
-        'description',
-        '1.0.0',
-        {
+        name: 'name',
+        description: 'description',
+        version: '1.0.0',
+        vars: {
           'name': BrickVariableProperties.string(
             defaultValue: 'Dash',
             description: 'Your name',
@@ -58,8 +65,8 @@ void main() {
             prompt: 'Are you a developer?',
           ),
         },
-        [],
-        [],
+        files: [],
+        hooks: [],
       );
       final hasCorrectVars = equals({
         'name': isA<BrickVariableProperties>()

--- a/packages/mason_cli/lib/src/commands/init.dart
+++ b/packages/mason_cli/lib/src/commands/init.dart
@@ -22,11 +22,12 @@ class InitCommand extends MasonCommand {
       return ExitCode.usage.code;
     }
     final fetchDone = logger.progress('Initializing');
-    final target = DirectoryGeneratorTarget(cwd, logger);
+    final target = DirectoryGeneratorTarget(cwd);
     final generator = _MasonYamlGenerator();
     await generator.generate(
       target,
       vars: <String, String>{'name': '{{name}}'},
+      logger: logger,
     );
     fetchDone();
 

--- a/packages/mason_cli/lib/src/commands/make.dart
+++ b/packages/mason_cli/lib/src/commands/make.dart
@@ -75,11 +75,7 @@ class _MakeCommand extends MasonCommand {
     final configPath = results['config-path'] as String?;
     final fileConflictResolution =
         (results['on-conflict'] as String).toFileConflictResolution();
-    final target = DirectoryGeneratorTarget(
-      Directory(outputDir),
-      logger,
-      fileConflictResolution,
-    );
+    final target = DirectoryGeneratorTarget(Directory(outputDir));
     final disableHooks = results['no-hooks'] as bool;
     final generator = await MasonGenerator.fromBrickYaml(_brick);
     final vars = <String, dynamic>{};
@@ -144,7 +140,12 @@ class _MakeCommand extends MasonCommand {
 
     final generateDone = logger.progress('Making ${generator.id}');
     try {
-      final fileCount = await generator.generate(target, vars: vars);
+      final fileCount = await generator.generate(
+        target,
+        vars: vars,
+        fileConflictResolution: fileConflictResolution,
+        logger: logger,
+      );
       generateDone('Made brick ${_brick.name}');
       logger.logFiles(fileCount);
 

--- a/packages/mason_cli/lib/src/commands/new.dart
+++ b/packages/mason_cli/lib/src/commands/new.dart
@@ -44,7 +44,7 @@ class NewCommand extends MasonCommand {
     }
 
     final done = logger.progress('Creating new brick: $name.');
-    final target = DirectoryGeneratorTarget(directory, logger);
+    final target = DirectoryGeneratorTarget(directory);
     final generator = _BrickGenerator(name, description);
     final newBrick = Brick(
       path: p.normalize(
@@ -58,7 +58,11 @@ class NewCommand extends MasonCommand {
 
     try {
       await Future.wait([
-        generator.generate(target, vars: <String, dynamic>{'name': '{{name}}'}),
+        generator.generate(
+          target,
+          vars: <String, dynamic>{'name': '{{name}}'},
+          logger: logger,
+        ),
         if (!masonYaml.bricks.containsKey(name))
           masonYamlFile.writeAsString(Yaml.encode(MasonYaml(bricks).toJson())),
       ]);

--- a/packages/mason_cli/test/mason_generator_test.dart
+++ b/packages/mason_cli/test/mason_generator_test.dart
@@ -27,7 +27,8 @@ void main() {
 
         final target = Directory.systemTemp.createTempSync();
         final fileCount = await generator.generate(
-          DirectoryGeneratorTarget(target, logger),
+          DirectoryGeneratorTarget(target),
+          logger: logger,
         );
         expect(fileCount, equals(1));
         expect(
@@ -47,7 +48,8 @@ void main() {
 
         final target = Directory.systemTemp.createTempSync();
         final fileCount = await generator.generate(
-          DirectoryGeneratorTarget(target, logger),
+          DirectoryGeneratorTarget(target),
+          logger: logger,
         );
         expect(fileCount, equals(1));
         expect(
@@ -79,8 +81,9 @@ void main() {
         );
 
         final fileCount = await generator.generate(
-          DirectoryGeneratorTarget(target, logger),
+          DirectoryGeneratorTarget(target),
           vars: vars,
+          logger: logger,
         );
         expect(fileCount, equals(1));
         expect(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

<!--- Describe your changes in detail -->

- `package:mason` Core API Updates
  - `MasonBundle`
    - Use named constructor parameters instead of positional parameters
  - `MasonGenerator.generate(...)`
    - Accepts optional `Logger` and `FileConflictResolution`
  - `DirectoryGeneratorTarget`
    - No longer accepts optional `Logger` and `FileConflictResolution` (moved to `generate` API above)

**Before**

```dart
final generator = MasonGenerator.fromBundle(myBundle);
final target = DirectoryGeneratorTarget(dir, Logger(), FileConflictResolution.skip);
await generator.generate(target, vars: {...});
```

**After**
```dart
final generator = MasonGenerator.fromBundle(myBundle);
final target = DirectoryGeneratorTarget(dir);
await generator.generate(
  DirectoryGeneratorTarget(tempDir),
  vars: {...},
  logger: Logger(), // optional logger
  fileConflictResolution: FileConflictResolution.skip, // optional conflict resolution strategy
);
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [X] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
