### PR TITLE
feat: remote brick download

### DIFF
--- a/.github/workflows/mason_cli.yaml
+++ b/.github/workflows/mason_cli.yaml
@@ -85,4 +85,4 @@ jobs:
           dart pub global activate pana
 
       - name: Verify Pub Score
-        run: ../../tool/verify_pub_score.sh
+        run: ../../tool/verify_pub_score.sh 90

--- a/packages/mason/CHANGELOG.md
+++ b/packages/mason/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.1.0-dev.7
+
+- **BREAKING**: refactor: remove `WriteBrickException`
+- **BREAKING**: refactor: `Brick` named constructors
+  - `Brick.path`, `Brick.git`, `Brick.version`
+- feat: add `MasonGenerator.fromRegistry`
+- feat: add `fromUniversalBundle` and `toUniversalBundle` on `MasonBundle`
+- feat: add `BrickLocation`
+- feat: add `unpackBundle` to convert universal bundle bytes to a `MasonBundle`
+
 # 0.1.0-dev.6
 
 - **BREAKING** feat: return list of `GeneratedFile` from `generate`

--- a/packages/mason/lib/mason.dart
+++ b/packages/mason/lib/mason.dart
@@ -6,10 +6,11 @@ library mason;
 
 export 'package:mason_logger/mason_logger.dart';
 
+export 'src/brick.dart' show Brick;
 export 'src/brick_yaml.dart'
     show BrickYaml, BrickVariableProperties, BrickVariableType;
 export 'src/bricks_json.dart' show BricksJson, WriteBrickException;
-export 'src/bundler.dart' show createBundle;
+export 'src/bundler.dart' show createBundle, unpackBundle;
 export 'src/exception.dart' show BrickNotFoundException, MasonException;
 export 'src/generator.dart'
     show
@@ -21,6 +22,6 @@ export 'src/generator.dart'
         MasonGenerator,
         TemplateFile;
 export 'src/mason_bundle.dart' show MasonBundle;
-export 'src/mason_yaml.dart' show Brick, GitPath, MasonYaml;
+export 'src/mason_yaml.dart' show BrickLocation, GitPath, MasonYaml;
 export 'src/render.dart' show RenderTemplate;
 export 'src/version.dart' show packageVersion;

--- a/packages/mason/lib/mason.dart
+++ b/packages/mason/lib/mason.dart
@@ -9,7 +9,8 @@ export 'package:mason_logger/mason_logger.dart';
 export 'src/brick.dart' show Brick;
 export 'src/brick_yaml.dart'
     show BrickYaml, BrickVariableProperties, BrickVariableType;
-export 'src/bricks_json.dart' show BricksJson, WriteBrickException;
+export 'src/bricks_json.dart'
+    show BricksJson, WriteBrickException, MasonYamlNameMismatch;
 export 'src/bundler.dart' show createBundle, unpackBundle;
 export 'src/exception.dart' show BrickNotFoundException, MasonException;
 export 'src/generator.dart'

--- a/packages/mason/lib/mason.dart
+++ b/packages/mason/lib/mason.dart
@@ -9,8 +9,7 @@ export 'package:mason_logger/mason_logger.dart';
 export 'src/brick.dart' show Brick;
 export 'src/brick_yaml.dart'
     show BrickYaml, BrickVariableProperties, BrickVariableType;
-export 'src/bricks_json.dart'
-    show BricksJson, WriteBrickException, MasonYamlNameMismatch;
+export 'src/bricks_json.dart' show BricksJson;
 export 'src/bundler.dart' show createBundle, unpackBundle;
 export 'src/exception.dart' show BrickNotFoundException, MasonException;
 export 'src/generator.dart'

--- a/packages/mason/lib/src/brick.dart
+++ b/packages/mason/lib/src/brick.dart
@@ -1,0 +1,42 @@
+import 'package:mason/mason.dart';
+import 'package:path/path.dart' as p;
+
+/// {@template brick}
+/// Metadata for a brick template including the name and location.
+/// {@endtemplate}
+class Brick {
+  /// {@macro brick}
+  const Brick({
+    required this.name,
+    required this.location,
+  });
+
+  /// Brick from a local path.
+  Brick.path(String path)
+      : this(
+          name: p.basenameWithoutExtension(path),
+          location: BrickLocation(path: path),
+        );
+
+  /// Brick from a git url.
+  Brick.git(GitPath git)
+      : this(
+          name: p.basenameWithoutExtension(
+            p.join(git.url, git.path).replaceAll(r'\', '/'),
+          ),
+          location: BrickLocation(git: git),
+        );
+
+  /// Brick from a version constraint.
+  Brick.version({required String name, required String version})
+      : this(
+          name: name,
+          location: BrickLocation(version: version),
+        );
+
+  /// The name of the brick.
+  final String name;
+
+  /// The location of the brick.
+  final BrickLocation location;
+}

--- a/packages/mason/lib/src/brick.dart
+++ b/packages/mason/lib/src/brick.dart
@@ -22,7 +22,7 @@ class Brick {
   Brick.git(GitPath git)
       : this(
           name: p.basenameWithoutExtension(
-            p.join(git.url, git.path).replaceAll(r'\', '/'),
+            p.join(git.url, git.path),
           ),
           location: BrickLocation(git: git),
         );

--- a/packages/mason/lib/src/bricks_json.dart
+++ b/packages/mason/lib/src/bricks_json.dart
@@ -237,7 +237,9 @@ class BricksJson {
         await tempDirectory.rename(directory.path);
       } catch (_) {}
       _ensureRemoteBrickExists(directory, gitPath);
-      final localPath = p.join(directory.path, gitPath.path);
+      final localPath = p
+          .canonicalize(p.join(directory.path, gitPath.path))
+          .replaceAll(r'\', '/');
       _cache[key] = localPath;
       return localPath;
     }
@@ -247,8 +249,9 @@ class BricksJson {
     await directory.create(recursive: true);
     await _clone(gitPath, directory);
     _ensureRemoteBrickExists(directory, gitPath);
-    final localPath = p.join(directory.path, gitPath.path);
-
+    final localPath = p
+        .canonicalize(p.join(directory.path, gitPath.path))
+        .replaceAll(r'\', '/');
     _cache[key] = localPath;
     return localPath;
   }

--- a/packages/mason/lib/src/bricks_json.dart
+++ b/packages/mason/lib/src/bricks_json.dart
@@ -237,7 +237,7 @@ class BricksJson {
         await tempDirectory.rename(directory.path);
       } catch (_) {}
       _ensureRemoteBrickExists(directory, gitPath);
-      final localPath = p.join(directory.path, gitPath.path);
+      final localPath = p.canonicalize(p.join(directory.path, gitPath.path));
       _cache[key] = localPath;
       return localPath;
     }
@@ -247,7 +247,7 @@ class BricksJson {
     await directory.create(recursive: true);
     await _clone(gitPath, directory);
     _ensureRemoteBrickExists(directory, gitPath);
-    final localPath = p.join(directory.path, gitPath.path);
+    final localPath = p.canonicalize(p.join(directory.path, gitPath.path));
     _cache[key] = localPath;
     return localPath;
   }

--- a/packages/mason/lib/src/bricks_json.dart
+++ b/packages/mason/lib/src/bricks_json.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:archive/archive.dart';
 import 'package:checked_yaml/checked_yaml.dart';
 import 'package:crypto/crypto.dart';
 import 'package:http/http.dart' as http;
@@ -154,13 +153,11 @@ class BricksJson {
   /// Caches brick if necessary and updates `bricks.json`.
   /// Returns the local path to the brick.
   Future<String> add(Brick brick) async {
-    final path = brick.location.path;
-    if (path != null) {
+    if (brick.location.path != null) {
       return _addLocalBrick(brick);
     }
 
-    final gitPath = brick.location.git;
-    if (gitPath != null) {
+    if (brick.location.git != null) {
       return _addRemoteBrickFromGit(brick);
     }
 
@@ -370,11 +367,7 @@ class BricksJson {
       throw BrickNotFoundException(uri.toString());
     }
 
-    final bundle = MasonBundle.fromJson(
-      json.decode(
-        utf8.decode(BZip2Decoder().decodeBytes(response.bodyBytes)),
-      ) as Map<String, dynamic>,
-    );
+    final bundle = MasonBundle.fromUniversalBundle(response.bodyBytes);
     unpackBundle(bundle, directory);
   }
 

--- a/packages/mason/lib/src/bricks_json.dart
+++ b/packages/mason/lib/src/bricks_json.dart
@@ -237,7 +237,8 @@ class BricksJson {
         await tempDirectory.rename(directory.path);
       } catch (_) {}
       _ensureRemoteBrickExists(directory, gitPath);
-      final localPath = p.join(directory.path, gitPath.path);
+      final localPath =
+          p.join(directory.path, gitPath.path).replaceAll(r'\', '/');
       _cache[key] = localPath;
       return localPath;
     }
@@ -247,7 +248,8 @@ class BricksJson {
     await directory.create(recursive: true);
     await _clone(gitPath, directory);
     _ensureRemoteBrickExists(directory, gitPath);
-    final localPath = p.join(directory.path, gitPath.path);
+    final localPath =
+        p.join(directory.path, gitPath.path).replaceAll(r'\', '/');
     _cache[key] = localPath;
     return localPath;
   }

--- a/packages/mason/lib/src/bricks_json.dart
+++ b/packages/mason/lib/src/bricks_json.dart
@@ -237,8 +237,7 @@ class BricksJson {
         await tempDirectory.rename(directory.path);
       } catch (_) {}
       _ensureRemoteBrickExists(directory, gitPath);
-      final localPath =
-          p.join(directory.path, gitPath.path).replaceAll(r'\', '/');
+      final localPath = p.canonicalize(p.join(directory.path, gitPath.path));
       _cache[key] = localPath;
       return localPath;
     }
@@ -248,8 +247,7 @@ class BricksJson {
     await directory.create(recursive: true);
     await _clone(gitPath, directory);
     _ensureRemoteBrickExists(directory, gitPath);
-    final localPath =
-        p.join(directory.path, gitPath.path).replaceAll(r'\', '/');
+    final localPath = p.canonicalize(p.join(directory.path, gitPath.path));
     _cache[key] = localPath;
     return localPath;
   }

--- a/packages/mason/lib/src/bricks_json.dart
+++ b/packages/mason/lib/src/bricks_json.dart
@@ -237,7 +237,7 @@ class BricksJson {
         await tempDirectory.rename(directory.path);
       } catch (_) {}
       _ensureRemoteBrickExists(directory, gitPath);
-      final localPath = p.canonicalize(p.join(directory.path, gitPath.path));
+      final localPath = p.join(directory.path, gitPath.path);
       _cache[key] = localPath;
       return localPath;
     }
@@ -247,7 +247,7 @@ class BricksJson {
     await directory.create(recursive: true);
     await _clone(gitPath, directory);
     _ensureRemoteBrickExists(directory, gitPath);
-    final localPath = p.canonicalize(p.join(directory.path, gitPath.path));
+    final localPath = p.join(directory.path, gitPath.path);
     _cache[key] = localPath;
     return localPath;
   }

--- a/packages/mason/lib/src/bricks_json.dart
+++ b/packages/mason/lib/src/bricks_json.dart
@@ -237,7 +237,7 @@ class BricksJson {
         await tempDirectory.rename(directory.path);
       } catch (_) {}
       _ensureRemoteBrickExists(directory, gitPath);
-      final localPath = p.canonicalize(p.join(directory.path, gitPath.path));
+      final localPath = p.join(directory.path, gitPath.path);
       _cache[key] = localPath;
       return localPath;
     }
@@ -247,7 +247,8 @@ class BricksJson {
     await directory.create(recursive: true);
     await _clone(gitPath, directory);
     _ensureRemoteBrickExists(directory, gitPath);
-    final localPath = p.canonicalize(p.join(directory.path, gitPath.path));
+    final localPath = p.join(directory.path, gitPath.path);
+
     _cache[key] = localPath;
     return localPath;
   }

--- a/packages/mason/lib/src/bricks_json.dart
+++ b/packages/mason/lib/src/bricks_json.dart
@@ -306,7 +306,6 @@ class BricksJson {
         'Unable to fetch versions for brick "${brick.name}".',
       );
     }
-
     if (response.statusCode == 404) {
       throw BrickResolveVersionException(
         'Brick "${brick.name}" does not exist.',

--- a/packages/mason/lib/src/bundler.dart
+++ b/packages/mason/lib/src/bundler.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:checked_yaml/checked_yaml.dart';
 import 'package:mason/mason.dart';
-import 'package:mason/src/brick_yaml.dart';
 import 'package:mason/src/mason_bundle.dart';
 import 'package:path/path.dart' as path;
 import 'package:universal_io/io.dart';

--- a/packages/mason/lib/src/generator.dart
+++ b/packages/mason/lib/src/generator.dart
@@ -109,7 +109,7 @@ class MasonGenerator extends Generator {
   /// a [GitPath] for a remote [BrickYaml] file.
   static Future<MasonGenerator> fromGitPath(GitPath gitPath) async {
     final directory = await BricksJson.temp().add(Brick.git(gitPath));
-    final file = File(p.join(directory, gitPath.path, BrickYaml.file));
+    final file = File(p.join(directory, BrickYaml.file));
     final brickYaml = checkedYamlDecode(
       file.readAsStringSync(),
       (m) => BrickYaml.fromJson(m!),

--- a/packages/mason/lib/src/generator.dart
+++ b/packages/mason/lib/src/generator.dart
@@ -108,7 +108,7 @@ class MasonGenerator extends Generator {
   /// Factory which creates a [MasonGenerator] based on
   /// a [GitPath] for a remote [BrickYaml] file.
   static Future<MasonGenerator> fromGitPath(GitPath gitPath) async {
-    final directory = await BricksJson.temp().add(Brick(git: gitPath));
+    final directory = await BricksJson.temp().add(Brick.git(gitPath));
     final file = File(p.join(directory, gitPath.path, BrickYaml.file));
     final brickYaml = checkedYamlDecode(
       file.readAsStringSync(),

--- a/packages/mason/lib/src/generator.dart
+++ b/packages/mason/lib/src/generator.dart
@@ -117,6 +117,23 @@ class MasonGenerator extends Generator {
     return MasonGenerator.fromBrickYaml(brickYaml);
   }
 
+  /// Factory which creates a [MasonGenerator] based on
+  /// a brick [name] and [version] hosted in a registry.
+  static Future<MasonGenerator> fromRegistry({
+    required String name,
+    required String version,
+  }) async {
+    final directory = await BricksJson.temp().add(
+      Brick.version(name: name, version: version),
+    );
+    final file = File(p.join(directory, BrickYaml.file));
+    final brickYaml = checkedYamlDecode(
+      file.readAsStringSync(),
+      (m) => BrickYaml.fromJson(m!),
+    ).copyWith(path: file.path);
+    return MasonGenerator.fromBrickYaml(brickYaml);
+  }
+
   /// Optional list of variables which will be used to populate
   /// the corresponding mustache variables within the template.
   final List<String> vars;

--- a/packages/mason/lib/src/mason_bundle.dart
+++ b/packages/mason/lib/src/mason_bundle.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+
+import 'package:archive/archive.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:mason/src/brick_yaml.dart';
 
@@ -47,6 +50,17 @@ class MasonBundle {
   factory MasonBundle.fromJson(Map<String, dynamic> json) =>
       _$MasonBundleFromJson(json);
 
+  /// Converts a universal bundle into a [MasonBundle] instance.
+  factory MasonBundle.fromUniversalBundle(List<int> bytes) {
+    return MasonBundle.fromJson(
+      json.decode(
+        utf8.decode(
+          BZip2Decoder().decodeBytes(bytes),
+        ),
+      ) as Map<String, dynamic>,
+    );
+  }
+
   /// List of all [MasonBundledFile] instances within the `__brick__` directory.
   final List<MasonBundledFile> files;
 
@@ -69,4 +83,9 @@ class MasonBundle {
 
   /// Converts a [MasonBundle] into a [Map<String, dynamic>].
   Map<String, dynamic> toJson() => _$MasonBundleToJson(this);
+
+  /// Converts a [MasonBundle] into universal bundle bytes.
+  List<int> toUniversalBundle() {
+    return BZip2Encoder().encode(utf8.encode(json.encode(toJson())));
+  }
 }

--- a/packages/mason/lib/src/mason_yaml.dart
+++ b/packages/mason/lib/src/mason_yaml.dart
@@ -11,8 +11,8 @@ part 'mason_yaml.g.dart';
 @JsonSerializable()
 class MasonYaml {
   /// {@macro mason_yaml}
-  const MasonYaml(Map<String, Brick>? bricks)
-      : bricks = bricks ?? const <String, Brick>{};
+  const MasonYaml(Map<String, BrickLocation>? bricks)
+      : bricks = bricks ?? const <String, BrickLocation>{};
 
   /// Converts [Map] to [MasonYaml]
   factory MasonYaml.fromJson(Map<dynamic, dynamic> json) =>
@@ -26,10 +26,10 @@ class MasonYaml {
   static const file = 'mason.yaml';
 
   /// static constant for an empty `mason.yaml` file.
-  static const empty = MasonYaml(<String, Brick>{});
+  static const empty = MasonYaml(<String, BrickLocation>{});
 
-  /// [Map] of [Brick] alias to [Brick] instances.
-  final Map<String, Brick> bricks;
+  /// [Map] of [BrickLocation] alias to [BrickLocation] instances.
+  final Map<String, BrickLocation> bricks;
 
   /// Finds nearest ancestor `mason.yaml` file
   /// relative to the [cwd].
@@ -46,27 +46,33 @@ class MasonYaml {
   }
 }
 
-/// {@template brick}
-/// Contains metadata for a reusable brick template.
+/// {@template brick_location}
+/// Contains metadata for the location of a reusable brick template.
 ///
 /// Used by [MasonYaml].
 /// {@endtemplate}
 @JsonSerializable()
-class Brick {
-  /// {@macro brick}
-  const Brick({this.path, this.git});
+class BrickLocation {
+  /// {@macro brick_location}
+  const BrickLocation({this.path, this.git, this.version});
 
-  /// Converts a [Map] to a [Brick].
-  factory Brick.fromJson(Map<dynamic, dynamic> json) => _$BrickFromJson(json);
+  /// Converts a [Map] to a [BrickLocation].
+  factory BrickLocation.fromJson(dynamic json) {
+    if (json is String) return BrickLocation(version: json);
+    return _$BrickLocationFromJson(json as Map);
+  }
 
-  /// Converts [Brick] to [Map]
-  Map<dynamic, dynamic> toJson() => _$BrickToJson(this);
+  /// Converts [BrickLocation] to [Map]
+  Map<dynamic, dynamic> toJson() => _$BrickLocationToJson(this);
 
   /// The local brick template path.
   final String? path;
 
   /// Git brick template path.
   final GitPath? git;
+
+  /// Brick version constraint.
+  final String? version;
 }
 
 /// {@template git_path}

--- a/packages/mason/lib/src/mason_yaml.g.dart
+++ b/packages/mason/lib/src/mason_yaml.g.dart
@@ -18,7 +18,7 @@ MasonYaml _$MasonYamlFromJson(Map json) => $checkedCreate(
           $checkedConvert(
               'bricks',
               (v) => (v as Map?)?.map(
-                    (k, e) => MapEntry(k as String, Brick.fromJson(e as Map)),
+                    (k, e) => MapEntry(k as String, BrickLocation.fromJson(e)),
                   )),
         );
         return val;
@@ -29,24 +29,25 @@ Map<String, dynamic> _$MasonYamlToJson(MasonYaml instance) => <String, dynamic>{
       'bricks': instance.bricks.map((k, e) => MapEntry(k, e.toJson())),
     };
 
-Brick _$BrickFromJson(Map json) => $checkedCreate(
-      'Brick',
+BrickLocation _$BrickLocationFromJson(Map json) => $checkedCreate(
+      'BrickLocation',
       json,
       ($checkedConvert) {
         $checkKeys(
           json,
-          allowedKeys: const ['path', 'git'],
+          allowedKeys: const ['path', 'git', 'version'],
         );
-        final val = Brick(
+        final val = BrickLocation(
           path: $checkedConvert('path', (v) => v as String?),
           git: $checkedConvert(
               'git', (v) => v == null ? null : GitPath.fromJson(v as Map)),
+          version: $checkedConvert('version', (v) => v as String?),
         );
         return val;
       },
     );
 
-Map<String, dynamic> _$BrickToJson(Brick instance) {
+Map<String, dynamic> _$BrickLocationToJson(BrickLocation instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -57,6 +58,7 @@ Map<String, dynamic> _$BrickToJson(Brick instance) {
 
   writeNotNull('path', instance.path);
   writeNotNull('git', instance.git?.toJson());
+  writeNotNull('version', instance.version);
   return val;
 }
 

--- a/packages/mason/lib/src/version.dart
+++ b/packages/mason/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.1.0-dev.6';
+const packageVersion = '0.1.0-dev.7';

--- a/packages/mason/pubspec.yaml
+++ b/packages/mason/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   meta: ^1.7.0
   mustache_template: ^2.0.0
   path: ^1.8.0
+  pub_semver: ^2.1.0
   recase: ^4.0.0
   universal_io: ^2.0.4
   yaml: ^3.1.0

--- a/packages/mason/pubspec.yaml
+++ b/packages/mason/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mason
 description: >
   A Dart template generator which helps teams generate files quickly and consistently.
-version: 0.1.0-dev.6
+version: 0.1.0-dev.7
 homepage: https://github.com/felangel/mason
 
 environment:

--- a/packages/mason/pubspec.yaml
+++ b/packages/mason/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
+  archive: ^3.1.11
   checked_yaml: ^2.0.1
   collection: ^1.15.0
   crypto: ^3.0.1

--- a/packages/mason/test/src/bricks_json_test.dart
+++ b/packages/mason/test/src/bricks_json_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: prefer_const_constructors
 
 import 'package:mason/mason.dart';
+import 'package:mason/src/bricks_json.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 import 'package:universal_io/io.dart';

--- a/packages/mason/test/src/bricks_json_test.dart
+++ b/packages/mason/test/src/bricks_json_test.dart
@@ -22,7 +22,7 @@ void main() {
 
       expect(bricksJson.encode, equals('{}'));
 
-      final brick = Brick(path: path.join('..', '..', 'bricks', 'simple'));
+      final brick = Brick.path(path.join('..', '..', 'bricks', 'simple'));
       final result = await bricksJson.add(brick);
 
       expect(result, isNotEmpty);
@@ -68,8 +68,8 @@ void main() {
         expect(file.existsSync(), isTrue);
         expect(bricksJson.encode, equals('{}'));
         final result = await bricksJson.add(
-          Brick(
-            git: GitPath(
+          Brick.git(
+            GitPath(
               'https://github.com/felangel/mason',
               path: 'bricks/simple',
             ),
@@ -84,8 +84,8 @@ void main() {
           'with existing empty directory', () async {
         final directory = Directory.systemTemp.createTempSync();
         final bricksJson = BricksJson(directory: directory);
-        final brick = Brick(
-          git: GitPath(
+        final brick = Brick.git(
+          GitPath(
             'https://github.com/felangel/mason',
             path: 'bricks/simple',
           ),
@@ -118,8 +118,8 @@ void main() {
         expect(file.existsSync(), isTrue);
         expect(bricksJson.encode, equals('{}'));
         final result = await bricksJson.add(
-          Brick(
-            git: GitPath(
+          Brick.git(
+            GitPath(
               'https://github.com/felangel/mason',
               path: 'bricks/simple',
               ref: 'master',
@@ -139,7 +139,7 @@ void main() {
         expect(file.existsSync(), isTrue);
         expect(bricksJson.encode, equals('{}'));
         final result = await bricksJson.add(
-          Brick(path: path.join('..', '..', 'bricks', 'simple')),
+          Brick.path(path.join('..', '..', 'bricks', 'simple')),
         );
         expect(result, isNotEmpty);
         expect(bricksJson.encode, contains('simple_'));
@@ -157,7 +157,7 @@ void main() {
         expect(bricksJson.encode, equals('{}'));
         expect(
           () => bricksJson.add(
-            Brick(git: GitPath('https://github.com/felangel/mason')),
+            Brick.git(GitPath('https://github.com/felangel/mason')),
           ),
           throwsA(isA<BrickNotFoundException>()),
         );
@@ -174,7 +174,7 @@ void main() {
         expect(file.existsSync(), isTrue);
         expect(bricksJson.encode, equals('{}'));
         expect(
-          () => bricksJson.add(Brick(path: 'simple')),
+          () => bricksJson.add(Brick.path('simple')),
           throwsA(isA<BrickNotFoundException>()),
         );
       });
@@ -191,7 +191,7 @@ void main() {
         expect(bricksJson.encode, equals('{}'));
         expect(file.readAsStringSync(), isEmpty);
         final result = await bricksJson.add(
-          Brick(path: path.join('..', '..', 'bricks', 'simple')),
+          Brick.path(path.join('..', '..', 'bricks', 'simple')),
         );
         expect(result, isNotEmpty);
         expect(bricksJson.encode, contains('simple_'));
@@ -210,7 +210,7 @@ void main() {
         ).createSync(recursive: true);
         expect(bricksJson.encode, equals('{}'));
 
-        final brick = Brick(path: path.join('..', '..', 'bricks', 'simple'));
+        final brick = Brick.path(path.join('..', '..', 'bricks', 'simple'));
         final result = await bricksJson.add(brick);
         expect(result, isNotEmpty);
         expect(bricksJson.encode, contains('simple_'));

--- a/packages/mason/test/src/bundler_test.dart
+++ b/packages/mason/test/src/bundler_test.dart
@@ -70,5 +70,73 @@ void main() {
         }
       });
     });
+
+    group('unpackBundle', () {
+      test('unpacks a MasonBundle (simple)', () {
+        final tempDir = Directory.systemTemp.createTempSync();
+        final bundle = createBundle(
+          Directory(path.join('..', '..', 'bricks', 'simple')),
+        );
+        unpackBundle(bundle, tempDir);
+        final yaml = File(path.join(tempDir.path, 'brick.yaml'));
+        expect(yaml.existsSync(), isTrue);
+        expect(
+          yaml.readAsStringSync(),
+          equals(
+            '''{"name":"simple","description":"A Simple Static Template","version":"0.1.0+1","vars":{}}''',
+          ),
+        );
+        final file = File(path.join(tempDir.path, '__brick__', 'HELLO.md'));
+        expect(file.existsSync(), isTrue);
+        expect(file.readAsStringSync(), equals('Hello World!'));
+      });
+
+      test('unpacks a MasonBundle (hooks)', () {
+        final tempDir = Directory.systemTemp.createTempSync();
+        final bundle = createBundle(
+          Directory(path.join('..', '..', 'bricks', 'hooks')),
+        );
+        unpackBundle(bundle, tempDir);
+        final yaml = File(path.join(tempDir.path, 'brick.yaml'));
+        expect(yaml.existsSync(), isTrue);
+        expect(
+          yaml.readAsStringSync(),
+          equals(
+            '''{"name":"hooks","description":"A Hooks Example Template","version":"0.1.0+1","vars":{"name":{"type":"string","description":"Your name","default":"Dash","prompt":"What is your name?"}}}''',
+          ),
+        );
+        final file = File(path.join(tempDir.path, '__brick__', 'hooks.md'));
+        expect(file.existsSync(), isTrue);
+        expect(file.readAsStringSync(), equals('Hi {{name}}!'));
+        final preGenHookFile = File(
+          path.join(tempDir.path, 'hooks', 'pre_gen.dart'),
+        );
+        expect(preGenHookFile.existsSync(), true);
+        expect(
+          preGenHookFile.readAsStringSync(),
+          equals(
+            '''import 'dart:io';import 'package:mason/mason.dart';void run(HookContext context){final file=File('.pre_gen.txt');file.writeAsStringSync('pre_gen: {{name}}');}''',
+          ),
+        );
+        final postGenHookFile = File(
+          path.join(tempDir.path, 'hooks', 'post_gen.dart'),
+        );
+        expect(postGenHookFile.existsSync(), true);
+        expect(
+          postGenHookFile.readAsStringSync(),
+          equals(
+            '''import 'dart:io';import 'package:mason/mason.dart';void run(HookContext context){final file=File('.post_gen.txt');file.writeAsStringSync('post_gen: {{name}}');}''',
+          ),
+        );
+        final hookPubspecFile = File(
+          path.join(tempDir.path, 'hooks', 'pubspec.yaml'),
+        );
+        expect(
+          hookPubspecFile.readAsStringSync(),
+          contains('name: hooks_hooks'),
+        );
+        expect(hookPubspecFile.existsSync(), true);
+      });
+    });
   });
 }

--- a/packages/mason/test/src/exception_test.dart
+++ b/packages/mason/test/src/exception_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: prefer_const_constructors
 
 import 'package:mason/mason.dart';
+import 'package:mason/src/bricks_json.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -13,10 +14,18 @@ void main() {
       });
     });
 
-    group('WriteBrickException', () {
+    group('BrickResolveVersionException', () {
       test('can be instantiated', () {
         const message = 'test message';
-        final exception = WriteBrickException(message);
+        final exception = BrickResolveVersionException(message);
+        expect(exception.message, equals(message));
+      });
+    });
+
+    group('BrickUnsatisfiedVersionConstraint', () {
+      test('can be instantiated', () {
+        const message = 'test message';
+        final exception = BrickUnsatisfiedVersionConstraint(message);
         expect(exception.message, equals(message));
       });
     });
@@ -26,6 +35,13 @@ void main() {
         const path = 'test path';
         final exception = BrickNotFoundException(path);
         expect(exception.message, equals('Could not find brick at $path'));
+      });
+    });
+
+    group('MasonYamlNameMismatch', () {
+      test('has the correct message', () {
+        const message = 'test message';
+        expect(MasonYamlNameMismatch(message).message, equals(message));
       });
     });
   });

--- a/packages/mason/test/src/generator_test.dart
+++ b/packages/mason/test/src/generator_test.dart
@@ -677,6 +677,30 @@ void main() {
       });
     });
 
+    group('.fromRegistry', () {
+      test('constructs an instance', () async {
+        const name = 'Dash';
+        final generator = await MasonGenerator.fromRegistry(
+          name: 'greeting',
+          version: '0.1.0+1',
+        );
+        final tempDir = Directory.systemTemp.createTempSync();
+
+        final files = await generator.generate(
+          DirectoryGeneratorTarget(tempDir),
+          vars: <String, dynamic>{'name': name},
+        );
+
+        final file = File(path.join(tempDir.path, 'GREETINGS.md'));
+        final generatedFile = files.first;
+        expect(files.length, equals(1));
+        expect(generatedFile.status, equals(GeneratedFileStatus.created));
+        expect(generatedFile.path, equals(file.path));
+        expect(file.existsSync(), isTrue);
+        expect(file.readAsStringSync(), equals('Hi $name!'));
+      });
+    });
+
     group('generate', () {
       test('generates app_icon from remote url', () async {
         const url =

--- a/packages/mason/test/src/generator_test.dart
+++ b/packages/mason/test/src/generator_test.dart
@@ -678,11 +678,77 @@ void main() {
     });
 
     group('.fromRegistry', () {
-      test('constructs an instance', () async {
+      test('constructs an instance (exact version)', () async {
         const name = 'Dash';
         final generator = await MasonGenerator.fromRegistry(
           name: 'greeting',
           version: '0.1.0+1',
+        );
+        final tempDir = Directory.systemTemp.createTempSync();
+
+        final files = await generator.generate(
+          DirectoryGeneratorTarget(tempDir),
+          vars: <String, dynamic>{'name': name},
+        );
+
+        final file = File(path.join(tempDir.path, 'GREETINGS.md'));
+        final generatedFile = files.first;
+        expect(files.length, equals(1));
+        expect(generatedFile.status, equals(GeneratedFileStatus.created));
+        expect(generatedFile.path, equals(file.path));
+        expect(file.existsSync(), isTrue);
+        expect(file.readAsStringSync(), equals('Hi $name!'));
+      });
+
+      test('constructs an instance (version constraint)', () async {
+        const name = 'Dash';
+        final generator = await MasonGenerator.fromRegistry(
+          name: 'greeting',
+          version: '^0.1.0',
+        );
+        final tempDir = Directory.systemTemp.createTempSync();
+
+        final files = await generator.generate(
+          DirectoryGeneratorTarget(tempDir),
+          vars: <String, dynamic>{'name': name},
+        );
+
+        final file = File(path.join(tempDir.path, 'GREETINGS.md'));
+        final generatedFile = files.first;
+        expect(files.length, equals(1));
+        expect(generatedFile.status, equals(GeneratedFileStatus.created));
+        expect(generatedFile.path, equals(file.path));
+        expect(file.existsSync(), isTrue);
+        expect(file.readAsStringSync(), equals('Hi $name!'));
+      });
+
+      test('constructs an instance (version range)', () async {
+        const name = 'Dash';
+        final generator = await MasonGenerator.fromRegistry(
+          name: 'greeting',
+          version: '>=0.1.0 <0.2.0',
+        );
+        final tempDir = Directory.systemTemp.createTempSync();
+
+        final files = await generator.generate(
+          DirectoryGeneratorTarget(tempDir),
+          vars: <String, dynamic>{'name': name},
+        );
+
+        final file = File(path.join(tempDir.path, 'GREETINGS.md'));
+        final generatedFile = files.first;
+        expect(files.length, equals(1));
+        expect(generatedFile.status, equals(GeneratedFileStatus.created));
+        expect(generatedFile.path, equals(file.path));
+        expect(file.existsSync(), isTrue);
+        expect(file.readAsStringSync(), equals('Hi $name!'));
+      });
+
+      test('constructs an instance (any version)', () async {
+        const name = 'Dash';
+        final generator = await MasonGenerator.fromRegistry(
+          name: 'greeting',
+          version: 'any',
         );
         final tempDir = Directory.systemTemp.createTempSync();
 

--- a/packages/mason/test/src/mason_bundle_test.dart
+++ b/packages/mason/test/src/mason_bundle_test.dart
@@ -123,5 +123,30 @@ void main() {
             .having((file) => file.description, 'description', description),
       );
     });
+
+    test('can be converted to/from universal bundle', () {
+      final instance = MasonBundle(
+        name: 'name',
+        description: 'description',
+        version: '1.0.0',
+        vars: {},
+        files: [],
+        hooks: [],
+      );
+      expect(
+        MasonBundle.fromUniversalBundle(instance.toUniversalBundle()),
+        isA<MasonBundle>()
+            .having((file) => file.name, 'name', instance.name)
+            .having((file) => file.version, 'version', instance.version)
+            .having((file) => file.vars, 'vars', instance.vars)
+            .having((file) => file.files, 'files', instance.files)
+            .having((file) => file.hooks, 'hooks', instance.hooks)
+            .having(
+              (file) => file.description,
+              'description',
+              instance.description,
+            ),
+      );
+    });
   });
 }

--- a/packages/mason/test/src/mason_yaml_test.dart
+++ b/packages/mason/test/src/mason_yaml_test.dart
@@ -8,14 +8,14 @@ import 'package:universal_io/io.dart';
 void main() {
   group('MasonYaml', () {
     test('can be (de)serialized', () {
-      final brick = Brick(path: '.');
-      final instance = MasonYaml({'example': brick});
+      final brickLocation = BrickLocation(path: '.');
+      final instance = MasonYaml({'example': brickLocation});
       final result = MasonYaml.fromJson(instance.toJson());
       expect(result.bricks.length, equals(1));
       expect(result.bricks.keys.first, equals('example'));
       expect(
         result.bricks.values.first,
-        isA<Brick>().having((b) => b.path, 'path', brick.path),
+        isA<BrickLocation>().having((b) => b.path, 'path', brickLocation.path),
       );
     });
 
@@ -51,17 +51,17 @@ void main() {
     });
   });
 
-  group('Brick', () {
+  group('BrickLocation', () {
     test('can be (de)serialized (path)', () {
-      final instance = Brick(path: '.');
+      final instance = BrickLocation(path: '.');
       expect(
-        Brick.fromJson(instance.toJson()),
-        isA<Brick>().having((b) => b.path, 'path', instance.path),
+        BrickLocation.fromJson(instance.toJson()),
+        isA<BrickLocation>().having((b) => b.path, 'path', instance.path),
       );
     });
 
     test('can be (de)serialized (gitPath)', () {
-      final instance = Brick(
+      final instance = BrickLocation(
         git: GitPath(
           'https://github.com/felangel/mason',
           ref: 'main',
@@ -69,7 +69,7 @@ void main() {
         ),
       );
       expect(
-        Brick.fromJson(instance.toJson()).git,
+        BrickLocation.fromJson(instance.toJson()).git,
         isA<GitPath>()
             .having((g) => g.url, 'url', instance.git!.url)
             .having((g) => g.ref, 'ref', instance.git!.ref)

--- a/packages/mason_cli/CHANGELOG.md
+++ b/packages/mason_cli/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.0-dev.11
+
+- fix: clear `bricks.json` prior to fetching via `mason get`
+- fix: verify/validate brick name matches name in `mason.yaml` during `mason get`
+- refactor: populate bricks from `bricks.json` directly
+- refactor: remove dependency on `package:archive`
+
 # 0.1.0-dev.10
 
 - **BREAKING** feat: upgrade to `mason ^0.1.0-dev.6`

--- a/packages/mason_cli/lib/src/command.dart
+++ b/packages/mason_cli/lib/src/command.dart
@@ -5,15 +5,6 @@ import 'package:mason/mason.dart';
 import 'package:path/path.dart' as p;
 import 'package:universal_io/io.dart';
 
-/// {@template mason_yaml_name_mismatch}
-/// Thrown when a brick's name in `mason.yaml` does not match
-/// the name in `brick.yaml`.
-/// {@endtemplate}
-class MasonYamlNameMismatch extends MasonException {
-  /// {@macro mason_yaml_name_mismatch}
-  MasonYamlNameMismatch(String message) : super(message);
-}
-
 /// {@template mason_yaml_not_found_exception}
 /// Thrown when a `mason.yaml` cannot be found locally.
 /// {@endtemplate}
@@ -39,6 +30,14 @@ class MasonYamlParseException extends MasonException {
 class BrickYamlParseException extends MasonException {
   /// {@macro brick_yaml_parse_exception}
   const BrickYamlParseException(String message) : super(message);
+}
+
+/// {@template malformed_bricks_json}
+/// Thrown when a brick from mason.yaml cannot be found in bricks.json.
+/// {@endtemplate}
+class MalformedBricksJson extends MasonException {
+  /// {@macro malformed_bricks_json}
+  const MalformedBricksJson(String message) : super(message);
 }
 
 /// {@template mason_command}
@@ -196,7 +195,12 @@ abstract class MasonCommand extends Command<int> {
     for (final entry in masonYaml.bricks.entries) {
       final brick = Brick(name: entry.key, location: entry.value);
       final dirPath = _cacheDirectory(brick);
-      if (dirPath == null) break;
+      if (dirPath == null) {
+        throw MalformedBricksJson(
+          'bricks.json does not contain brick "${brick.name}". '
+          'Did you forget to run "mason get"?',
+        );
+      }
       final filePath = brick.location.path != null
           ? p.join(dirPath, BrickYaml.file)
           : p.join(dirPath, brick.location.git?.path ?? '', BrickYaml.file);

--- a/packages/mason_cli/lib/src/command.dart
+++ b/packages/mason_cli/lib/src/command.dart
@@ -194,12 +194,12 @@ abstract class MasonCommand extends Command<int> {
   Set<BrickYaml> _getBricks(MasonYaml masonYaml) {
     final bricks = <BrickYaml>{};
     for (final entry in masonYaml.bricks.entries) {
-      final brick = entry.value;
+      final brick = Brick(name: entry.key, location: entry.value);
       final dirPath = _cacheDirectory(brick);
       if (dirPath == null) break;
-      final filePath = brick.path != null
+      final filePath = brick.location.path != null
           ? p.join(dirPath, BrickYaml.file)
-          : p.join(dirPath, brick.git?.path ?? '', BrickYaml.file);
+          : p.join(dirPath, brick.location.git?.path ?? '', BrickYaml.file);
       final file = File(filePath);
       if (!file.existsSync()) throw BrickNotFoundException(filePath);
       try {

--- a/packages/mason_cli/lib/src/command.dart
+++ b/packages/mason_cli/lib/src/command.dart
@@ -176,7 +176,7 @@ abstract class MasonCommand extends Command<int> {
       final dirPath = entry.value;
       final filePath = p.join(dirPath, BrickYaml.file);
       final file = File(filePath);
-      if (!file.existsSync()) throw BrickNotFoundException(filePath);
+      if (!file.existsSync()) throw BrickNotFoundException(dirPath);
       try {
         final brickYaml = checkedYamlDecode(
           file.readAsStringSync(),

--- a/packages/mason_cli/lib/src/commands/add.dart
+++ b/packages/mason_cli/lib/src/commands/add.dart
@@ -73,7 +73,7 @@ class AddCommand extends MasonCommand {
         brick = Brick.git(gitPath);
         try {
           final directory = await bricksJson.add(brick);
-          file = File(p.join(directory, gitPath.path, BrickYaml.file));
+          file = File(p.join(directory, BrickYaml.file));
         } catch (_) {
           throw UsageException('brick not found at url $location', usage);
         }

--- a/packages/mason_cli/lib/src/commands/add.dart
+++ b/packages/mason_cli/lib/src/commands/add.dart
@@ -62,7 +62,7 @@ class AddCommand extends MasonCommand {
         if (!file.existsSync()) {
           throw UsageException('brick not found at path $location', usage);
         }
-        brick = Brick(path: file.parent.path);
+        brick = Brick.path(file.parent.path);
         await bricksJson.add(brick);
       } else {
         final gitPath = GitPath(
@@ -70,7 +70,7 @@ class AddCommand extends MasonCommand {
           path: results['path'] as String?,
           ref: results['ref'] as String?,
         );
-        brick = Brick(git: gitPath);
+        brick = Brick.git(gitPath);
         try {
           final directory = await bricksJson.add(brick);
           file = File(p.join(directory, gitPath.path, BrickYaml.file));
@@ -90,7 +90,7 @@ class AddCommand extends MasonCommand {
     final targetMasonYaml = isGlobal ? globalMasonYaml : masonYaml;
     final targetMasonYamlFile = isGlobal ? globalMasonYamlFile : masonYamlFile;
     final bricks = Map.of(targetMasonYaml.bricks)
-      ..addAll({brickYaml.name: brick});
+      ..addAll({brickYaml.name: brick.location});
     final addDone = logger.progress('Adding ${brickYaml.name}');
     try {
       if (!targetMasonYaml.bricks.containsKey(name)) {

--- a/packages/mason_cli/lib/src/commands/bundle.dart
+++ b/packages/mason_cli/lib/src/commands/bundle.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:archive/archive.dart';
 import 'package:args/command_runner.dart';
 import 'package:mason/mason.dart';
 import 'package:mason_cli/src/command.dart';
@@ -108,10 +107,7 @@ Future<String> _generateUniversalBundle(
 ) async {
   final file = File(path.join(outputDir, '${bundle.name}.bundle'));
   await file.create(recursive: true);
-  final compressedBundle = BZip2Encoder().encode(
-    utf8.encode(json.encode(bundle.toJson())),
-  );
-  await file.writeAsBytes(compressedBundle);
+  await file.writeAsBytes(bundle.toUniversalBundle());
   return path.canonicalize(file.path);
 }
 

--- a/packages/mason_cli/lib/src/commands/bundle.dart
+++ b/packages/mason_cli/lib/src/commands/bundle.dart
@@ -55,7 +55,7 @@ class BundleCommand extends MasonCommand {
     }
     final brick = Directory(results.rest.first);
     if (!brick.existsSync()) {
-      throw MasonException('could not find brick at ${brick.path}');
+      throw BrickNotFoundException(brick.path);
     }
 
     final bundle = createBundle(brick);

--- a/packages/mason_cli/lib/src/commands/get.dart
+++ b/packages/mason_cli/lib/src/commands/get.dart
@@ -20,6 +20,7 @@ class GetCommand extends MasonCommand {
     if (bricksJson == null) throw const MasonYamlNotFoundException();
     final getDone = logger.progress('Getting bricks');
     try {
+      bricksJson.clear();
       if (masonYaml.bricks.entries.isNotEmpty) {
         await Future.forEach<MapEntry<String, BrickLocation>>(
           masonYaml.bricks.entries,

--- a/packages/mason_cli/lib/src/commands/get.dart
+++ b/packages/mason_cli/lib/src/commands/get.dart
@@ -20,8 +20,13 @@ class GetCommand extends MasonCommand {
     if (bricksJson == null) throw const MasonYamlNotFoundException();
     final getDone = logger.progress('Getting bricks');
     try {
-      if (masonYaml.bricks.values.isNotEmpty) {
-        await Future.forEach(masonYaml.bricks.values, bricksJson.add);
+      if (masonYaml.bricks.entries.isNotEmpty) {
+        await Future.forEach<MapEntry<String, BrickLocation>>(
+          masonYaml.bricks.entries,
+          (entry) => bricksJson.add(
+            Brick(name: entry.key, location: entry.value),
+          ),
+        );
       }
     } finally {
       await bricksJson.flush();

--- a/packages/mason_cli/lib/src/commands/init.dart
+++ b/packages/mason_cli/lib/src/commands/init.dart
@@ -35,8 +35,13 @@ class InitCommand extends MasonCommand {
     final bricksJson = localBricksJson;
     if (bricksJson == null) throw const MasonYamlNotFoundException();
     try {
-      if (masonYaml.bricks.values.isNotEmpty) {
-        await Future.forEach(masonYaml.bricks.values, bricksJson.add);
+      if (masonYaml.bricks.entries.isNotEmpty) {
+        await Future.forEach<MapEntry<String, BrickLocation>>(
+          masonYaml.bricks.entries,
+          (entry) => bricksJson.add(
+            Brick(name: entry.key, location: entry.value),
+          ),
+        );
       }
     } finally {
       await bricksJson.flush();

--- a/packages/mason_cli/lib/src/commands/new.dart
+++ b/packages/mason_cli/lib/src/commands/new.dart
@@ -46,15 +46,15 @@ class NewCommand extends MasonCommand {
     final done = logger.progress('Creating new brick: $name.');
     final target = DirectoryGeneratorTarget(directory);
     final generator = _BrickGenerator(name, description);
-    final newBrick = Brick(
-      path: p.normalize(
+    final newBrick = Brick.path(
+      p.normalize(
         p.relative(
           brickYaml.parent.path,
           from: entryPoint.path,
         ),
       ),
     );
-    final bricks = Map.of(masonYaml.bricks)..addAll({name: newBrick});
+    final bricks = Map.of(masonYaml.bricks)..addAll({name: newBrick.location});
 
     try {
       await Future.wait([

--- a/packages/mason_cli/lib/src/commands/remove.dart
+++ b/packages/mason_cli/lib/src/commands/remove.dart
@@ -32,15 +32,15 @@ class RemoveCommand extends MasonCommand {
     final isGlobal = results['global'] == true;
     final bricksJson = isGlobal ? globalBricksJson : localBricksJson;
     final targetMasonYaml = isGlobal ? globalMasonYaml : masonYaml;
-    final brick = targetMasonYaml.bricks[brickName];
-    if (bricksJson == null || brick == null) {
+    final brickLocation = targetMasonYaml.bricks[brickName];
+    if (bricksJson == null || brickLocation == null) {
       throw UsageException('no brick named $brickName was found', usage);
     }
 
     final targetMasonYamlFile = isGlobal ? globalMasonYamlFile : masonYamlFile;
     final removeDone = logger.progress('Removing $brickName');
     try {
-      bricksJson.remove(brick);
+      bricksJson.remove(Brick(name: brickName, location: brickLocation));
       final bricks = Map.of(targetMasonYaml.bricks)
         ..removeWhere((key, value) => key == brickName);
 

--- a/packages/mason_cli/lib/src/version.dart
+++ b/packages/mason_cli/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.1.0-dev.10';
+const packageVersion = '0.1.0-dev.11';

--- a/packages/mason_cli/pubspec.yaml
+++ b/packages/mason_cli/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  archive: ^3.1.11
   args: ^2.1.0
   checked_yaml: ^2.0.1
   mason: ^0.1.0-dev.6

--- a/packages/mason_cli/pubspec.yaml
+++ b/packages/mason_cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mason_cli
 description: >
   Mason CLI allows developers to create and consume reusable templates called bricks.
-version: 0.1.0-dev.10
+version: 0.1.0-dev.11
 homepage: https://github.com/felangel/mason
 
 environment:

--- a/packages/mason_cli/test/commands/bundle_test.dart
+++ b/packages/mason_cli/test/commands/bundle_test.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:archive/archive.dart';
 import 'package:mason/mason.dart' hide packageVersion;
 import 'package:mason_cli/src/command_runner.dart';
 import 'package:mason_cli/src/version.dart';
@@ -60,8 +59,8 @@ void main() {
           'greeting.bundle',
         ),
       );
-      final actual = utf8.decode(
-        BZip2Decoder().decodeBytes(file.readAsBytesSync()),
+      final actual = json.encode(
+        MasonBundle.fromUniversalBundle(file.readAsBytesSync()).toJson(),
       );
       const expected =
           '''{"files":[{"path":"GREETINGS.md","data":"SGkge3tuYW1lfX0h","type":"text"}],"hooks":[],"name":"greeting","description":"A Simple Greeting Template","version":"0.1.0+1","vars":{"name":{"type":"string","description":"Your name","default":"Dash","prompt":"What is your name?"}}}''';
@@ -94,8 +93,8 @@ void main() {
           'hooks.bundle',
         ),
       );
-      final actual = utf8.decode(
-        BZip2Decoder().decodeBytes(file.readAsBytesSync()),
+      final actual = json.encode(
+        MasonBundle.fromUniversalBundle(file.readAsBytesSync()).toJson(),
       );
       expect(
         actual,

--- a/packages/mason_cli/test/commands/bundle_test.dart
+++ b/packages/mason_cli/test/commands/bundle_test.dart
@@ -262,7 +262,7 @@ void main() {
       final result = await commandRunner.run(['bundle', brickPath]);
       expect(result, equals(ExitCode.usage.code));
       verify(
-        () => logger.err('could not find brick at $brickPath'),
+        () => logger.err('Could not find brick at $brickPath'),
       ).called(1);
       verifyNever(() => logger.progress(any()));
     });

--- a/packages/mason_cli/test/commands/get_test.dart
+++ b/packages/mason_cli/test/commands/get_test.dart
@@ -120,7 +120,7 @@ bricks:
                 simplePath,
             '''todos_c8800221272babb429e8e7e5cbfce6912dcb605ea323643c52b1a9ea71f4f244''':
                 todosPath,
-            widgetPath: masonUrl,
+            widgetPath: '$masonUrl/bricks/widget',
           }),
         ),
       );
@@ -227,9 +227,8 @@ bricks:
         logger: logger,
         pubUpdater: pubUpdater,
       );
-      final expectedErrorMessage = MasonYamlNameMismatch(
-        '''brick name "app_icon1" doesn't match provided name "app_icon" in mason.yaml.''',
-      ).message;
+      const expectedErrorMessage =
+          '''Brick name "app_icon1" doesn't match provided name "app_icon" in mason.yaml.''';
       final getResult = await commandRunner.run(['get']);
       expect(getResult, equals(ExitCode.usage.code));
       verify(() => logger.err(expectedErrorMessage)).called(1);

--- a/packages/mason_cli/test/commands/get_test.dart
+++ b/packages/mason_cli/test/commands/get_test.dart
@@ -98,12 +98,14 @@ bricks:
       final todosPath = path.canonicalize(
         path.join(Directory.current.path, bricksPath, 'todos'),
       );
-      const widgetPath =
-          '''widget_536b4405bffd371ab46f0948d0a5b9a2ac2cddb270ebc3d6f684217f7741422f''';
-      final masonUrl = path.join(
-        BricksJson.rootDir.path,
-        'git',
-        '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
+      final widgetPath = path.canonicalize(
+        path.join(
+          BricksJson.rootDir.path,
+          'git',
+          '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
+          'bricks',
+          'widget',
+        ),
       );
 
       expect(
@@ -120,7 +122,8 @@ bricks:
                 simplePath,
             '''todos_c8800221272babb429e8e7e5cbfce6912dcb605ea323643c52b1a9ea71f4f244''':
                 todosPath,
-            widgetPath: '$masonUrl/bricks/widget',
+            '''widget_536b4405bffd371ab46f0948d0a5b9a2ac2cddb270ebc3d6f684217f7741422f''':
+                widgetPath,
           }),
         ),
       );

--- a/packages/mason_cli/test/commands/get_test.dart
+++ b/packages/mason_cli/test/commands/get_test.dart
@@ -98,15 +98,17 @@ bricks:
       final todosPath = path.canonicalize(
         path.join(Directory.current.path, bricksPath, 'todos'),
       );
-      final widgetPath = path.canonicalize(
-        path.join(
-          BricksJson.rootDir.path,
-          'git',
-          '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
-          'bricks',
-          'widget',
-        ),
-      );
+      final widgetPath = path
+          .canonicalize(
+            path.join(
+              BricksJson.rootDir.path,
+              'git',
+              '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
+              'bricks',
+              'widget',
+            ),
+          )
+          .replaceAll(r'\', '/');
 
       expect(
         File(expectedBrickJsonPath).readAsStringSync(),

--- a/packages/mason_cli/test/commands/get_test.dart
+++ b/packages/mason_cli/test/commands/get_test.dart
@@ -213,6 +213,28 @@ bricks:
       ).called(1);
     });
 
+    test(
+        'throws MasonYamlNameMismatch '
+        'when mason.yaml contains mismatch', () async {
+      File(path.join(Directory.current.path, 'mason.yaml')).writeAsStringSync(
+        '''
+bricks:
+  app_icon1:
+    path: ../../../../../bricks/app_icon
+''',
+      );
+      commandRunner = MasonCommandRunner(
+        logger: logger,
+        pubUpdater: pubUpdater,
+      );
+      final expectedErrorMessage = MasonYamlNameMismatch(
+        '''brick name "app_icon1" doesn't match provided name "app_icon" in mason.yaml.''',
+      ).message;
+      final getResult = await commandRunner.run(['get']);
+      expect(getResult, equals(ExitCode.usage.code));
+      verify(() => logger.err(expectedErrorMessage)).called(1);
+    });
+
     test('throws ProcessException when remote does not exist', () async {
       File(path.join(Directory.current.path, 'mason.yaml')).writeAsStringSync(
         '''

--- a/packages/mason_cli/test/commands/make_test.dart
+++ b/packages/mason_cli/test/commands/make_test.dart
@@ -423,7 +423,7 @@ bricks:
     });
 
     test('exits with code 64 when bricks.json contains bad path', () async {
-      final badPath = path.canonicalize(path.join('bricks', 'greeting'));
+      final badPath = path.join('bricks', 'greeting');
       File(path.join(Directory.current.path, '.mason', 'bricks.json'))
           .writeAsStringSync(
         '''

--- a/packages/mason_cli/test/commands/make_test.dart
+++ b/packages/mason_cli/test/commands/make_test.dart
@@ -436,9 +436,10 @@ bricks:
       );
       final makeResult = await commandRunner.run(['make', 'greeting']);
       expect(makeResult, equals(ExitCode.usage.code));
-      final resultPath = path.join(badPath, 'brick.yaml');
-      final expectedErrorMessage = 'Could not find brick at $resultPath';
-      verify(() => logger.err(expectedErrorMessage)).called(1);
+      const expectedErrorMessage = 'Could not find brick at ';
+      verify(
+        () => logger.err(any(that: contains(expectedErrorMessage))),
+      ).called(1);
     });
 
     test('exits with code 64 when variable input has type mismatch', () async {

--- a/packages/mason_cli/test/commands/make_test.dart
+++ b/packages/mason_cli/test/commands/make_test.dart
@@ -423,11 +423,10 @@ bricks:
     });
 
     test('exits with code 64 when bricks.json contains bad path', () async {
-      final badPath = path.join('bricks', 'greeting');
       File(path.join(Directory.current.path, '.mason', 'bricks.json'))
           .writeAsStringSync(
         '''
-{"greeting1_2ed43fe1a1c8b94465c0d608ba790a35bdc48fdd039be2d87807d5bc8196e54e":"$badPath"}
+{"greeting1_2ed43fe1a1c8b94465c0d608ba790a35bdc48fdd039be2d87807d5bc8196e54e":"bricks/greeting"}
 ''',
       );
       commandRunner = MasonCommandRunner(

--- a/packages/mason_cli/test/commands/make_test.dart
+++ b/packages/mason_cli/test/commands/make_test.dart
@@ -435,10 +435,9 @@ bricks:
       );
       final makeResult = await commandRunner.run(['make', 'greeting']);
       expect(makeResult, equals(ExitCode.usage.code));
-      const expectedErrorMessage = 'Could not find brick at ';
-      verify(
-        () => logger.err(any(that: contains(expectedErrorMessage))),
-      ).called(1);
+      const expectedErrorMessage =
+          'Could not find brick at bricks/greeting/brick.yaml';
+      verify(() => logger.err(expectedErrorMessage)).called(1);
     });
 
     test('exits with code 64 when variable input has type mismatch', () async {

--- a/packages/mason_cli/test/commands/make_test.dart
+++ b/packages/mason_cli/test/commands/make_test.dart
@@ -435,8 +435,8 @@ bricks:
       );
       final makeResult = await commandRunner.run(['make', 'greeting']);
       expect(makeResult, equals(ExitCode.usage.code));
-      const expectedErrorMessage =
-          '''Could not find brick at bricks/greeting/brick.yaml''';
+      final resultPath = path.join('bricks', 'greeting', 'brick.yaml');
+      final expectedErrorMessage = 'Could not find brick at $resultPath';
       verify(() => logger.err(expectedErrorMessage)).called(1);
     });
 

--- a/packages/mason_cli/test/commands/make_test.dart
+++ b/packages/mason_cli/test/commands/make_test.dart
@@ -423,10 +423,11 @@ bricks:
     });
 
     test('exits with code 64 when bricks.json contains bad path', () async {
+      final badPath = path.canonicalize(path.join('bricks', 'greeting'));
       File(path.join(Directory.current.path, '.mason', 'bricks.json'))
           .writeAsStringSync(
         '''
-{"greeting1_2ed43fe1a1c8b94465c0d608ba790a35bdc48fdd039be2d87807d5bc8196e54e":"bricks/greeting"}
+{"greeting1_2ed43fe1a1c8b94465c0d608ba790a35bdc48fdd039be2d87807d5bc8196e54e":"$badPath"}
 ''',
       );
       commandRunner = MasonCommandRunner(
@@ -435,7 +436,7 @@ bricks:
       );
       final makeResult = await commandRunner.run(['make', 'greeting']);
       expect(makeResult, equals(ExitCode.usage.code));
-      final resultPath = path.join('bricks', 'greeting', 'brick.yaml');
+      final resultPath = path.join(badPath, 'brick.yaml');
       final expectedErrorMessage = 'Could not find brick at $resultPath';
       verify(() => logger.err(expectedErrorMessage)).called(1);
     });

--- a/packages/mason_cli/test/commands/make_test.dart
+++ b/packages/mason_cli/test/commands/make_test.dart
@@ -435,8 +435,7 @@ bricks:
       );
       final makeResult = await commandRunner.run(['make', 'greeting']);
       expect(makeResult, equals(ExitCode.usage.code));
-      const expectedErrorMessage =
-          'Could not find brick at bricks/greeting/brick.yaml';
+      const expectedErrorMessage = 'Could not find brick at bricks/greeting';
       verify(() => logger.err(expectedErrorMessage)).called(1);
     });
 

--- a/packages/mason_cli/test/commands/make_test.dart
+++ b/packages/mason_cli/test/commands/make_test.dart
@@ -414,13 +414,15 @@ bricks:
       );
       final makeResult = await commandRunner.run(['make', 'app_icon1']);
       expect(makeResult, equals(ExitCode.usage.code));
-      final expectedErrorMessage = MasonYamlNameMismatch(
-        '''brick name "app_icon" doesn't match provided name "app_icon1" in mason.yaml.''',
-      ).message;
-      verify(() => logger.err(expectedErrorMessage)).called(1);
+      const expectedErrorMessage =
+          '''Could not find a subcommand named "app_icon1" for "mason make".''';
+
+      verify(
+        () => logger.err(any(that: contains(expectedErrorMessage))),
+      ).called(1);
     });
 
-    test('exits with code 64 when bricks.json contains mismatch', () async {
+    test('exits with code 64 when bricks.json contains bad path', () async {
       File(path.join(Directory.current.path, '.mason', 'bricks.json'))
           .writeAsStringSync(
         '''
@@ -433,9 +435,8 @@ bricks:
       );
       final makeResult = await commandRunner.run(['make', 'greeting']);
       expect(makeResult, equals(ExitCode.usage.code));
-      final expectedErrorMessage = MasonYamlNameMismatch(
-        '''bricks.json does not contain brick "app_icon". Did you forget to run "mason get"?''',
-      ).message;
+      const expectedErrorMessage =
+          '''Could not find brick at bricks/greeting/brick.yaml''';
       verify(() => logger.err(expectedErrorMessage)).called(1);
     });
 

--- a/packages/mason_cli/test/commands/remove_test.dart
+++ b/packages/mason_cli/test/commands/remove_test.dart
@@ -76,15 +76,17 @@ void main() {
 
         const key =
             '''widget_536b4405bffd371ab46f0948d0a5b9a2ac2cddb270ebc3d6f684217f7741422f''';
-        final value = p.canonicalize(
-          p.join(
-            BricksJson.rootDir.path,
-            'git',
-            '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
-            'bricks',
-            'widget',
-          ),
-        );
+        final value = p
+            .canonicalize(
+              p.join(
+                BricksJson.rootDir.path,
+                'git',
+                '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
+                'bricks',
+                'widget',
+              ),
+            )
+            .replaceAll(r'\', '/');
         final bricksJson = File(
           p.join(Directory.current.path, '.mason', 'bricks.json'),
         );
@@ -109,15 +111,17 @@ void main() {
 
         const key =
             '''widget_536b4405bffd371ab46f0948d0a5b9a2ac2cddb270ebc3d6f684217f7741422f''';
-        final value = p.canonicalize(
-          p.join(
-            BricksJson.rootDir.path,
-            'git',
-            '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
-            'bricks',
-            'widget',
-          ),
-        );
+        final value = p
+            .canonicalize(
+              p.join(
+                BricksJson.rootDir.path,
+                'git',
+                '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
+                'bricks',
+                'widget',
+              ),
+            )
+            .replaceAll(r'\', '/');
         final bricksJson = File(
           p.join(Directory.current.path, '.mason', 'bricks.json'),
         );
@@ -169,15 +173,17 @@ void main() {
 
         const key =
             '''widget_536b4405bffd371ab46f0948d0a5b9a2ac2cddb270ebc3d6f684217f7741422f''';
-        final value = p.canonicalize(
-          p.join(
-            BricksJson.rootDir.path,
-            'git',
-            '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
-            'bricks',
-            'widget',
-          ),
-        );
+        final value = p
+            .canonicalize(
+              p.join(
+                BricksJson.rootDir.path,
+                'git',
+                '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
+                'bricks',
+                'widget',
+              ),
+            )
+            .replaceAll(r'\', '/');
         final bricksJson = File(
           p.join(BricksJson.globalDir.path, '.mason', 'bricks.json'),
         );

--- a/packages/mason_cli/test/commands/remove_test.dart
+++ b/packages/mason_cli/test/commands/remove_test.dart
@@ -76,12 +76,14 @@ void main() {
 
         const key =
             '''widget_536b4405bffd371ab46f0948d0a5b9a2ac2cddb270ebc3d6f684217f7741422f''';
-        final value = p.join(
-          BricksJson.rootDir.path,
-          'git',
-          '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
-          'bricks',
-          'widget',
+        final value = p.canonicalize(
+          p.join(
+            BricksJson.rootDir.path,
+            'git',
+            '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
+            'bricks',
+            'widget',
+          ),
         );
         final bricksJson = File(
           p.join(Directory.current.path, '.mason', 'bricks.json'),
@@ -107,12 +109,14 @@ void main() {
 
         const key =
             '''widget_536b4405bffd371ab46f0948d0a5b9a2ac2cddb270ebc3d6f684217f7741422f''';
-        final value = p.join(
-          BricksJson.rootDir.path,
-          'git',
-          '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
-          'bricks',
-          'widget',
+        final value = p.canonicalize(
+          p.join(
+            BricksJson.rootDir.path,
+            'git',
+            '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
+            'bricks',
+            'widget',
+          ),
         );
         final bricksJson = File(
           p.join(Directory.current.path, '.mason', 'bricks.json'),
@@ -165,12 +169,14 @@ void main() {
 
         const key =
             '''widget_536b4405bffd371ab46f0948d0a5b9a2ac2cddb270ebc3d6f684217f7741422f''';
-        final value = p.join(
-          BricksJson.rootDir.path,
-          'git',
-          '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
-          'bricks',
-          'widget',
+        final value = p.canonicalize(
+          p.join(
+            BricksJson.rootDir.path,
+            'git',
+            '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
+            'bricks',
+            'widget',
+          ),
         );
         final bricksJson = File(
           p.join(BricksJson.globalDir.path, '.mason', 'bricks.json'),

--- a/packages/mason_cli/test/commands/remove_test.dart
+++ b/packages/mason_cli/test/commands/remove_test.dart
@@ -80,6 +80,8 @@ void main() {
           BricksJson.rootDir.path,
           'git',
           '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
+          'bricks',
+          'widget',
         );
         final bricksJson = File(
           p.join(Directory.current.path, '.mason', 'bricks.json'),
@@ -109,6 +111,8 @@ void main() {
           BricksJson.rootDir.path,
           'git',
           '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
+          'bricks',
+          'widget',
         );
         final bricksJson = File(
           p.join(Directory.current.path, '.mason', 'bricks.json'),
@@ -165,6 +169,8 @@ void main() {
           BricksJson.rootDir.path,
           'git',
           '''mason_60e936dbe81fab0463b4efd5a396c50e4fcf52484fe2aa189d46874215a10b52''',
+          'bricks',
+          'widget',
         );
         final bricksJson = File(
           p.join(BricksJson.globalDir.path, '.mason', 'bricks.json'),

--- a/packages/mason_cli/test/src/command_test.dart
+++ b/packages/mason_cli/test/src/command_test.dart
@@ -40,7 +40,9 @@ void main() {
       });
 
       test('is thrown when brick.yaml is malformed', () async {
-        final directory = Directory.systemTemp.createTempSync();
+        final tempDirectory = Directory.systemTemp.createTempSync();
+        final directory = Directory(path.join(tempDirectory.path, 'malformed'))
+          ..createSync(recursive: true);
         final brickYaml = File(path.join(directory.path, 'brick.yaml'))
           ..writeAsStringSync(
             '''

--- a/packages/mason_cli/test/src/command_test.dart
+++ b/packages/mason_cli/test/src/command_test.dart
@@ -48,6 +48,7 @@ void main() {
             '''
 name: malformed
 description: A malformed Template
+version: 0.1.0+1
 ''',
           );
         File(path.join(directory.path, 'mason.yaml')).writeAsStringSync(

--- a/packages/mason_cli/test/src/command_test.dart
+++ b/packages/mason_cli/test/src/command_test.dart
@@ -18,13 +18,6 @@ void main() {
       Directory.current = cwd;
     });
 
-    group('MasonYamlNameMismatch', () {
-      test('has the correct message', () {
-        const message = 'test message';
-        expect(MasonYamlNameMismatch(message).message, equals(message));
-      });
-    });
-
     group('MasonYamlNotFoundException', () {
       test('has the correct message', () {
         const message =


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

<!--- Describe your changes in detail -->
### package:mason

- **BREAKING**: refactor: remove `WriteBrickException`
- **BREAKING**: refactor: `Brick` named constructors
  - `Brick.path`, `Brick.git`, `Brick.version`
- feat: add `MasonGenerator.fromRegistry`
- feat: add `fromUniversalBundle` and `toUniversalBundle` on `MasonBundle`
- feat: add `BrickLocation`
- feat: add `unpackBundle` to convert universal bundle bytes to a `MasonBundle`

### package:mason_cli
- fix: clear `bricks.json` prior to fetching via `mason get`
- fix: verify/validate brick name matches name in `mason.yaml` during `mason get`
- refactor: populate bricks from `bricks.json` directly
- refactor: remove dependency on `package:archive`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
