### PR TITLE
fix(mason_logger): multiline prompts are outputting twice

### DIFF
--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -161,8 +161,9 @@ class Logger {
     final input =
         hidden ? _readLineHiddenSync() : _stdin.readLineSync()?.trim();
     final response = input == null || input.isEmpty ? _defaultValue : input;
+    final lines = _message.split('\n').length - 1;
     _stdout.writeln(
-      '''\x1b[A\u001B[2K$_message${styleDim.wrap(lightCyan.wrap(hidden ? '******' : response))}''',
+      '''\x1b[A\u001B[2K\u001B[${lines}A$_message${styleDim.wrap(lightCyan.wrap(hidden ? '******' : response))}''',
     );
     return response;
   }
@@ -176,8 +177,9 @@ class Logger {
     final response = input == null || input.isEmpty
         ? defaultValue
         : input.toBoolean() ?? defaultValue;
+    final lines = _message.split('\n').length - 1;
     _stdout.writeln(
-      '''\x1b[A\u001B[2K$_message${styleDim.wrap(lightCyan.wrap(response ? 'Yes' : 'No'))}''',
+      '''\x1b[A\u001B[2K\u001B[${lines}A$_message${styleDim.wrap(lightCyan.wrap(response ? 'Yes' : 'No'))}''',
     );
     return response;
   }

--- a/packages/mason_logger/test/src/mason_logger_test.dart
+++ b/packages/mason_logger/test/src/mason_logger_test.dart
@@ -172,7 +172,7 @@ void main() {
             const response = 'test response';
             const prompt = '$message ';
             final promptWithResponse =
-                '''\x1b[A\u001B[2K$message ${styleDim.wrap(lightCyan.wrap(response))}''';
+                '''\x1b[A\u001B[2K\u001B[0A$message ${styleDim.wrap(lightCyan.wrap(response))}''';
             when(() => stdin.readLineSync()).thenReturn(response);
             final actual = Logger().prompt(message);
             expect(actual, equals(response));
@@ -192,7 +192,7 @@ void main() {
             const response = 'test response';
             final prompt = '$message ${darkGray.wrap('($defaultValue)')} ';
             final promptWithResponse =
-                '''\x1b[A\u001B[2K$prompt${styleDim.wrap(lightCyan.wrap(response))}''';
+                '''\x1b[A\u001B[2K\u001B[0A$prompt${styleDim.wrap(lightCyan.wrap(response))}''';
             when(() => stdin.readLineSync()).thenReturn(response);
             final actual = Logger().prompt(message, defaultValue: defaultValue);
             expect(actual, equals(response));
@@ -212,7 +212,7 @@ void main() {
             const response = 'test response';
             final prompt = '$message ${darkGray.wrap('($defaultValue)')} ';
             final promptWithResponse =
-                '''\x1b[A\u001B[2K$prompt${styleDim.wrap(lightCyan.wrap('******'))}''';
+                '''\x1b[A\u001B[2K\u001B[0A$prompt${styleDim.wrap(lightCyan.wrap('******'))}''';
             final bytes = [
               116,
               101,
@@ -249,6 +249,26 @@ void main() {
           stdin: () => stdin,
         );
       });
+
+      test('writes multi line to stdout and resets after response', () {
+        StdioOverrides.runZoned(
+          () {
+            const message = 'test message\nwith more\nlines';
+            final lines = message.split('\n').length - 1;
+            const response = 'test response';
+            const prompt = '$message ';
+            final promptWithResponse =
+                '''\x1b[A\u001B[2K\u001B[${lines}A$message ${styleDim.wrap(lightCyan.wrap(response))}''';
+            when(() => stdin.readLineSync()).thenReturn(response);
+            final actual = Logger().prompt(message);
+            expect(actual, equals(response));
+            verify(() => stdout.write(prompt)).called(1);
+            verify(() => stdout.writeln(promptWithResponse)).called(1);
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
     });
 
     group('.confirm', () {
@@ -258,7 +278,7 @@ void main() {
             const message = 'test message';
             final prompt = 'test message ${darkGray.wrap('(y/N)')} ';
             final promptWithResponse =
-                '''\x1b[A\u001B[2K$prompt${styleDim.wrap(lightCyan.wrap('No'))}''';
+                '''\x1b[A\u001B[2K\u001B[0A$prompt${styleDim.wrap(lightCyan.wrap('No'))}''';
             when(() => stdin.readLineSync()).thenReturn('');
             final actual = Logger().confirm(message);
             expect(actual, isFalse);
@@ -276,7 +296,7 @@ void main() {
             const message = 'test message';
             final prompt = 'test message ${darkGray.wrap('(Y/n)')} ';
             final promptWithResponse =
-                '''\x1b[A\u001B[2K$prompt${styleDim.wrap(lightCyan.wrap('Yes'))}''';
+                '''\x1b[A\u001B[2K\u001B[0A$prompt${styleDim.wrap(lightCyan.wrap('Yes'))}''';
             when(() => stdin.readLineSync()).thenReturn('y');
             final actual = Logger().confirm(message, defaultValue: true);
             expect(actual, isTrue);
@@ -296,7 +316,7 @@ void main() {
             const yesWords = ['y', 'Y', 'Yes', 'yes', 'yeah', 'yea', 'yup'];
             for (final word in yesWords) {
               final promptWithResponse =
-                  '''\x1b[A\u001B[2K$prompt${styleDim.wrap(lightCyan.wrap('Yes'))}''';
+                  '''\x1b[A\u001B[2K\u001B[0A$prompt${styleDim.wrap(lightCyan.wrap('Yes'))}''';
               when(() => stdin.readLineSync()).thenReturn(word);
               final actual = Logger().confirm(message);
               expect(actual, isTrue);
@@ -317,7 +337,7 @@ void main() {
             const noWords = ['n', 'N', 'No', 'no', 'nope', 'Nope', 'nopE'];
             for (final word in noWords) {
               final promptWithResponse =
-                  '''\x1b[A\u001B[2K$prompt${styleDim.wrap(lightCyan.wrap('No'))}''';
+                  '''\x1b[A\u001B[2K\u001B[0A$prompt${styleDim.wrap(lightCyan.wrap('No'))}''';
               when(() => stdin.readLineSync()).thenReturn(word);
               final actual = Logger().confirm(message);
               expect(actual, isFalse);
@@ -336,7 +356,7 @@ void main() {
             const message = 'test message';
             final prompt = 'test message ${darkGray.wrap('(y/N)')} ';
             final promptWithResponse =
-                '''\x1b[A\u001B[2K$prompt${styleDim.wrap(lightCyan.wrap('No'))}''';
+                '''\x1b[A\u001B[2K\u001B[0A$prompt${styleDim.wrap(lightCyan.wrap('No'))}''';
             when(() => stdin.readLineSync()).thenReturn('maybe');
             final actual = Logger().confirm(message);
             expect(actual, isFalse);
@@ -354,7 +374,7 @@ void main() {
             const message = 'test message';
             final prompt = 'test message ${darkGray.wrap('(Y/n)')} ';
             final promptWithResponse =
-                '''\x1b[A\u001B[2K$prompt${styleDim.wrap(lightCyan.wrap('Yes'))}''';
+                '''\x1b[A\u001B[2K\u001B[0A$prompt${styleDim.wrap(lightCyan.wrap('Yes'))}''';
             when(() => stdin.readLineSync()).thenReturn('maybe');
             final actual = Logger().confirm(message, defaultValue: true);
             expect(actual, isTrue);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

Ready

## Description

Both `prompt` and `confirm` do not support multi-line messages, when we write the message after getting the result we dont move the cursor up the amount of lines in the message.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
