### PR TITLE
fix shorthand regex

### DIFF
--- a/packages/mason/lib/src/render.dart
+++ b/packages/mason/lib/src/render.dart
@@ -101,7 +101,7 @@ extension RenderTemplate on String {
 
 extension on String {
   String transpiled(Map<String, dynamic> vars) {
-    final delimeterRegExp = RegExp('({?{{.*?}}}?)');
+    final delimeterRegExp = RegExp(r'''({?{{.*?\(\)}}}?)''');
     final lambdasRegExp = RegExp(
       r'''((.*).(camelCase|constantCase|dotCase|headerCase|lowerCase|pascalCase|paramCase|pathCase|sentenceCase|snakeCase|titleCase|upperCase)\(\))''',
     );
@@ -114,9 +114,7 @@ extension on String {
       if (group == null) return this;
 
       final isTriple = group.startsWith('{{{') && group.endsWith('}}}');
-      final groupContents = isTriple
-          ? group.substring(3, group.length - 3)
-          : group.substring(2, group.length - 2);
+      final groupContents = isTriple ? group.substring(3, group.length - 3) : group.substring(2, group.length - 2);
 
       return groupContents.replaceAllMapped(lambdasRegExp, (lambdaMatch) {
         final lambdaGroup = lambdaMatch.group(1);

--- a/packages/mason/test/src/render_test.dart
+++ b/packages/mason/test/src/render_test.dart
@@ -62,8 +62,7 @@ void main() {
 
       test('constantCase outputs correct string', () {
         const greeting = 'hello world';
-        const input =
-            'Greeting: {{#constantCase}}{{greeting}}{{/constantCase}}!';
+        const input = 'Greeting: {{#constantCase}}{{greeting}}{{/constantCase}}!';
         const expected = 'Greeting: HELLO_WORLD!';
         expect(
           input.render(<String, dynamic>{'greeting': greeting}),
@@ -133,8 +132,7 @@ void main() {
 
       test('sentenceCase outputs correct string', () {
         const greeting = 'hello world';
-        const input =
-            'Greeting: {{#sentenceCase}}{{greeting}}{{/sentenceCase}}!';
+        const input = 'Greeting: {{#sentenceCase}}{{greeting}}{{/sentenceCase}}!';
         const expected = 'Greeting: Hello world!';
         expect(
           input.render(<String, dynamic>{'greeting': greeting}),
@@ -317,11 +315,35 @@ void main() {
       test('support multiple unescaped lambdas', () {
         const greeting = '"hello world"';
         const name = '"dash"';
-        const input =
-            '''Greeting: {{{greeting.upperCase()}}} Name: {{{name.upperCase()}}}!''';
+        const input = '''Greeting: {{{greeting.upperCase()}}} Name: {{{name.upperCase()}}}!''';
         const expected = 'Greeting: "HELLO WORLD" Name: "DASH"!';
         expect(
           input.render(<String, dynamic>{'greeting': greeting, 'name': name}),
+          equals(expected),
+        );
+      });
+
+      test('mixed with regular mustache syntax', () {
+        const greeting = 'hello world';
+        const input = 'Greeting: {{greeting.upperCase()}}{{#is_yelling}}!{{/is_yelling}}';
+        var expected = 'Greeting: HELLO WORLD!';
+        expect(
+          input.render(
+            <String, dynamic>{
+              'greeting': greeting,
+              'is_yelling': true,
+            },
+          ),
+          equals(expected),
+        );
+        expected = 'Greeting: HELLO WORLD';
+        expect(
+          input.render(
+            <String, dynamic>{
+              'greeting': greeting,
+              'is_yelling': false,
+            },
+          ),
           equals(expected),
         );
       });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

This will update the shorthand regex to only match if the variable ends with '()'. Without these changes, mixing regular mustache syntax with thew new shorthand syntax will produce bad results. For example: 
`Greeting: {{greeting.upperCase()}}{{#is_yelling}}!{{/is_yelling}}` with 'greeting' set to 'hello world' and 'is_yelling' set to true will produce: `Greeting: HELLO WORLD#is_yelling/is_yelling`. 
With these changes the output would look like `Greeting: HELLO WORLD!`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
