### PR TITLE
Fix: Allow regular mustache syntax before shorthand syntax in string

### DIFF
--- a/packages/mason/lib/src/render.dart
+++ b/packages/mason/lib/src/render.dart
@@ -101,7 +101,7 @@ extension RenderTemplate on String {
 
 extension on String {
   String transpiled(Map<String, dynamic> vars) {
-    final delimeterRegExp = RegExp(r'''({?{{.*?\(\)}}}?)''');
+    final delimeterRegExp = RegExp(r'''({?{{[^{{]*?\(\)}}}?)''');
     final lambdasRegExp = RegExp(
       r'''((.*).(camelCase|constantCase|dotCase|headerCase|lowerCase|pascalCase|paramCase|pathCase|sentenceCase|snakeCase|titleCase|upperCase)\(\))''',
     );

--- a/packages/mason/test/src/render_test.dart
+++ b/packages/mason/test/src/render_test.dart
@@ -326,16 +326,16 @@ void main() {
         );
       });
 
-      test('mixed with regular mustache syntax', () {
+      test('mixed with regular mustache syntax after', () {
         const greeting = 'hello world';
         const input =
-            'Greeting: {{greeting.upperCase()}}{{#is_yelling}}!{{/is_yelling}}';
+            'Greeting: {{greeting.upperCase()}}{{#is_suffixed}}!{{/is_suffixed}}';
         var expected = 'Greeting: HELLO WORLD!';
         expect(
           input.render(
             <String, dynamic>{
               'greeting': greeting,
-              'is_yelling': true,
+              'is_suffixed': true,
             },
           ),
           equals(expected),
@@ -345,7 +345,33 @@ void main() {
           input.render(
             <String, dynamic>{
               'greeting': greeting,
-              'is_yelling': false,
+              'is_suffixed': false,
+            },
+          ),
+          equals(expected),
+        );
+      });
+
+      test('mixed with regular mustache syntax before', () {
+        const greeting = 'hello world';
+        const input =
+            '{{#is_prefixed}}Greeting: {{/is_prefixed}}{{greeting.upperCase()}}!';
+        var expected = 'Greeting: HELLO WORLD!';
+        expect(
+          input.render(
+            <String, dynamic>{
+              'greeting': greeting,
+              'is_prefixed': true,
+            },
+          ),
+          equals(expected),
+        );
+        expected = 'HELLO WORLD!';
+        expect(
+          input.render(
+            <String, dynamic>{
+              'greeting': greeting,
+              'is_prefixed': false,
             },
           ),
           equals(expected),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Don't allow `{{` in between `{{}}` or `{{{}}}` in the regex when matching for shorthand so that other variables are not accidentally caught in the middle. 

Currently:
Renderer will match everything in between the very first `{{` and the very last `}}` in `{{#is_prefixed}}Greeting: {{/is_prefixed}}{{greeting.upperCase()}}!` when looking for shorthands, so it will replace `#is_prefixed}}Greeting: {{/is_prefixed}}{{greeting.upperCase()`. 

With these changes: 
Renderer will only match and replace `{{greeting.upperCase()}}`


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
