### PR TITLE
feat(widget): simplify widget brick to use SizedBox

### DIFF
--- a/bricks/widget/__brick__/{{name.snakeCase()}}.dart
+++ b/bricks/widget/__brick__/{{name.snakeCase()}}.dart
@@ -1,17 +1,10 @@
 import 'package:flutter/material.dart';
 
 class {{name.pascalCase()}} extends StatelessWidget {
-  const {{name.pascalCase()}}({
-    Key? key,
-    required this.child,
-  }) : super(key: key);
-
-  final Widget child;
+  const {{name.pascalCase()}}({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: child,
-    );
+    return const SizedBox();
   }
 }

--- a/bricks/widget/__brick__/{{name.snakeCase()}}.dart
+++ b/bricks/widget/__brick__/{{name.snakeCase()}}.dart
@@ -1,7 +1,12 @@
 import 'package:flutter/material.dart';
 
 class {{name.pascalCase()}} extends StatelessWidget {
-  const {{name.pascalCase()}}({Key key}) : super(key: key);
+  const {{name.pascalCase()}}({
+    Key? key,
+    required this.child,
+  }) : super(key: key);
+
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY/IN DEVELOPMENT/HOLD**

## Description

I started to explore bricks and noticed that the configuration of widget brick is off. This could go the other way too - to remove the `child` in `Container`, but I guess it's better to put more code in this brick, rather than less. I also made `key` nullable as I suppose this should be null-safe.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
