### PR TITLE
fix(mason_logger): err should write to `stderr`

### DIFF
--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -79,9 +79,9 @@ class Logger {
   final _queue = <String?>[];
   final StdioOverrides? _overrides = StdioOverrides.current;
 
-  io.Stdout get _stderr => _overrides?.stderr ?? io.stderr;
   io.Stdout get _stdout => _overrides?.stdout ?? io.stdout;
   io.Stdin get _stdin => _overrides?.stdin ?? io.stdin;
+  io.Stdout get _stderr => _overrides?.stderr ?? io.stderr;
 
   /// Flushes internal message queue.
   void flush([Function(String?)? print]) {

--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -46,8 +46,7 @@ abstract class StdioOverrides {
   /// The [io.Stdin] that will be used within the current [Zone].
   io.Stdin get stdin => io.stdin;
 
-  /// The [io.Stdout] that will be used for errors and
-  /// within the current [Zone].
+  /// The [io.Stdout] that will be used for errors within the current [Zone].
   io.Stdout get stderr => io.stderr;
 }
 
@@ -107,7 +106,7 @@ class Logger {
     return Progress(message, _stdout, _stderr);
   }
 
-  /// Writes error message to stdout.
+  /// Writes error message to stderr.
   void err(String? message) => _stderr.writeln(lightRed.wrap(message));
 
   /// Writes alert message to stdout.
@@ -118,7 +117,7 @@ class Logger {
   /// Writes detail message to stdout.
   void detail(String? message) => _stdout.writeln(darkGray.wrap(message));
 
-  /// Writes warning message to stdout.
+  /// Writes warning message to stderr.
   void warn(String? message, {String tag = 'WARN'}) {
     _stderr.writeln(yellow.wrap(styleBold.wrap('[$tag] $message')));
   }

--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -120,7 +120,7 @@ class Logger {
 
   /// Writes warning message to stdout.
   void warn(String? message, {String tag = 'WARN'}) {
-    _stdout.writeln(yellow.wrap(styleBold.wrap('[$tag] $message')));
+    _stderr.writeln(yellow.wrap(styleBold.wrap('[$tag] $message')));
   }
 
   /// Writes success message to stdout.

--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -8,7 +8,11 @@ import 'package:universal_io/io.dart';
 /// {@endtemplate}
 class Progress {
   /// {@macro progress}
-  Progress(this._message, this._stdout) : _stopwatch = Stopwatch() {
+  Progress(
+    this._message,
+    this._stdout,
+    this._stderr,
+  ) : _stopwatch = Stopwatch() {
     _stopwatch
       ..reset()
       ..start();
@@ -27,6 +31,8 @@ class Progress {
     '⠇',
     '⠏'
   ];
+
+  final Stdout _stderr;
 
   final Stdout _stdout;
 
@@ -60,7 +66,7 @@ class Progress {
     _timer.cancel();
     final time =
         (_stopwatch.elapsed.inMilliseconds / 1000.0).toStringAsFixed(1);
-    _stdout.write(
+    _stderr.write(
       '''\b${'\b' * (_message.length + 4)}\u001b[2K${red.wrap('✗')} ${update ?? _message} ${darkGray.wrap('(${time}s)')}\n''',
     );
     _stopwatch.stop();

--- a/packages/mason_logger/test/src/mason_logger_test.dart
+++ b/packages/mason_logger/test/src/mason_logger_test.dart
@@ -11,10 +11,12 @@ void main() {
   group('Logger', () {
     late Stdout stdout;
     late Stdin stdin;
+    late Stdout stderr;
 
     setUp(() {
       stdout = MockStdout();
       stdin = MockStdin();
+      stderr = MockStdout();
     });
 
     group('.write', () {
@@ -26,6 +28,17 @@ void main() {
             verify(() => stdout.write(message)).called(1);
           },
           stdout: () => stdout,
+        );
+      });
+
+      test('writes to stderr', () {
+        StdioOverrides.runZoned(
+          () {
+            const message = 'test message';
+            Logger().write(message);
+            verify(() => stderr.write(message)).called(1);
+          },
+          stdout: () => stderr,
         );
       });
     });

--- a/packages/mason_logger/test/src/mason_logger_test.dart
+++ b/packages/mason_logger/test/src/mason_logger_test.dart
@@ -133,33 +133,33 @@ void main() {
     });
 
     group('.warn', () {
-      test('writes line to stdout', () {
+      test('writes line to stderr', () {
         StdioOverrides.runZoned(
           () {
             const message = 'test message';
             Logger().warn(message);
             verify(
               () {
-                stdout.writeln(yellow.wrap(styleBold.wrap('[WARN] $message')));
+                stderr.writeln(yellow.wrap(styleBold.wrap('[WARN] $message')));
               },
             ).called(1);
           },
-          stdout: () => stdout,
+          stderr: () => stderr,
         );
       });
 
-      test('writes line to stdout with custom tag', () {
+      test('writes line to stderr with custom tag', () {
         StdioOverrides.runZoned(
           () {
             const message = 'test message';
             Logger().warn(message, tag: '🚨');
             verify(
               () {
-                stdout.writeln(yellow.wrap(styleBold.wrap('[🚨] $message')));
+                stderr.writeln(yellow.wrap(styleBold.wrap('[🚨] $message')));
               },
             ).called(1);
           },
-          stdout: () => stdout,
+          stderr: () => stderr,
         );
       });
     });

--- a/packages/mason_logger/test/src/mason_logger_test.dart
+++ b/packages/mason_logger/test/src/mason_logger_test.dart
@@ -30,17 +30,6 @@ void main() {
           stdout: () => stdout,
         );
       });
-
-      test('writes to stdout', () {
-        StdioOverrides.runZoned(
-          () {
-            const message = 'test message';
-            Logger().write(message);
-            verify(() => stdout.write(message)).called(1);
-          },
-          stdout: () => stdout,
-        );
-      });
     });
 
     group('.info', () {

--- a/packages/mason_logger/test/src/mason_logger_test.dart
+++ b/packages/mason_logger/test/src/mason_logger_test.dart
@@ -31,14 +31,14 @@ void main() {
         );
       });
 
-      test('writes to stderr', () {
+      test('writes to stdout', () {
         StdioOverrides.runZoned(
           () {
             const message = 'test message';
             Logger().write(message);
-            verify(() => stderr.write(message)).called(1);
+            verify(() => stdout.write(message)).called(1);
           },
-          stdout: () => stderr,
+          stdout: () => stdout,
         );
       });
     });
@@ -92,14 +92,14 @@ void main() {
     });
 
     group('.err', () {
-      test('writes line to stdout', () {
+      test('writes line to stderr', () {
         StdioOverrides.runZoned(
           () {
             const message = 'test message';
             Logger().err(message);
-            verify(() => stdout.writeln(lightRed.wrap(message))).called(1);
+            verify(() => stderr.writeln(lightRed.wrap(message))).called(1);
           },
-          stdout: () => stdout,
+          stderr: () => stderr,
         );
       });
     });

--- a/packages/mason_logger/test/src/progress_test.dart
+++ b/packages/mason_logger/test/src/progress_test.dart
@@ -11,10 +11,12 @@ void main() {
   group('Progress', () {
     late Stdout stdout;
     late Stdin stdin;
+    late Stdout stderr;
 
     setUp(() {
       stdout = MockStdout();
       stdin = MockStdin();
+      stderr = MockStdout();
     });
 
     group('.complete', () {
@@ -22,7 +24,7 @@ void main() {
         await StdioOverrides.runZoned(
           () async {
             const message = 'test message';
-            final progress = Progress(message, stdout);
+            final progress = Progress(message, stdout, stderr);
             await Future<void>.delayed(const Duration(milliseconds: 100));
             progress.complete();
             verify(
@@ -42,16 +44,17 @@ void main() {
           },
           stdout: () => stdout,
           stdin: () => stdin,
+          stderr: () => stderr,
         );
       });
     });
 
     group('.fail', () {
-      test('writes lines to stdout', () async {
+      test('writes lines to stderr', () async {
         await StdioOverrides.runZoned(
           () async {
             const message = 'test message';
-            final progress = Progress(message, stdout);
+            final progress = Progress(message, stdout, stderr);
             await Future<void>.delayed(const Duration(milliseconds: 100));
             progress.fail();
             verify(
@@ -63,7 +66,7 @@ void main() {
             ).called(1);
             verify(
               () {
-                stdout.write(
+                stderr.write(
                   '''\b${'\b' * (message.length + 4)}\u001b[2K${red.wrap('✗')} $message ${darkGray.wrap('(0.1s)')}\n''',
                 );
               },
@@ -71,6 +74,7 @@ void main() {
           },
           stdout: () => stdout,
           stdin: () => stdin,
+          stderr: () => stderr,
         );
       });
     });
@@ -80,7 +84,7 @@ void main() {
         await StdioOverrides.runZoned(
           () async {
             const message = 'test message';
-            final progress = Progress(message, stdout);
+            final progress = Progress(message, stdout, stderr);
             await Future<void>.delayed(const Duration(milliseconds: 100));
             progress.cancel();
             verify(
@@ -96,6 +100,7 @@ void main() {
           },
           stdout: () => stdout,
           stdin: () => stdin,
+          stderr: () => stderr,
         );
       });
     });
@@ -105,7 +110,7 @@ void main() {
         await StdioOverrides.runZoned(
           () async {
             const message = 'test message';
-            final progress = Progress(message, stdout);
+            final progress = Progress(message, stdout, stderr);
             await Future<void>.delayed(const Duration(milliseconds: 100));
             // ignore: deprecated_member_use_from_same_package
             progress();
@@ -126,6 +131,7 @@ void main() {
           },
           stdout: () => stdout,
           stdin: () => stdin,
+          stderr: () => stderr,
         );
       });
     });


### PR DESCRIPTION
Fixes #362: `Progress.fail` & `err` should write to `stderr`

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**/IN DEVELOPMENT/HOLD

## Description

Updates `mason_logger` to use `stderr` where relevant:
- `Progess.fail`
- `Logger.err`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
