### PR TITLE
docs(mason_cli): fix app_icon link in README

### DIFF
--- a/packages/mason_cli/README.md
+++ b/packages/mason_cli/README.md
@@ -338,7 +338,7 @@ And the following brick template:
 
 `__brick__/{{% url %}}`
 
-Running `mason make app_icon --url path/to/icon.png` will generate `icon.png` with the contents of `path/to/icon.png` where the `path/to/icon.png` can be either a local or remote path. Check out the [app icon example brick](bricks/app_icon) to try it out.
+Running `mason make app_icon --url path/to/icon.png` will generate `icon.png` with the contents of `path/to/icon.png` where the `path/to/icon.png` can be either a local or remote path. Check out the [app icon example brick](../../bricks/app_icon) to try it out.
 
 #### Built-in Lambdas
 

--- a/packages/mason_cli/README.md
+++ b/packages/mason_cli/README.md
@@ -338,7 +338,7 @@ And the following brick template:
 
 `__brick__/{{% url %}}`
 
-Running `mason make app_icon --url path/to/icon.png` will generate `icon.png` with the contents of `path/to/icon.png` where the `path/to/icon.png` can be either a local or remote path. Check out the [app icon example brick](../../bricks/app_icon) to try it out.
+Running `mason make app_icon --url path/to/icon.png` will generate `icon.png` with the contents of `path/to/icon.png` where the `path/to/icon.png` can be either a local or remote path. Check out the [app icon example brick](https://github.com/felangel/mason/tree/master/bricks/app_icon) to try it out.
 
 #### Built-in Lambdas
 


### PR DESCRIPTION
## Status

READY

## Description

Update the broken link for `app icon example brick` in `mason_cli`'s `README.md`

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
