### PR TITLE
feat(mason_logger): add ProgressOptions API

### DIFF
--- a/packages/mason_logger/lib/mason_logger.dart
+++ b/packages/mason_logger/lib/mason_logger.dart
@@ -3,4 +3,5 @@ library mason_logger;
 export 'src/io.dart';
 export 'src/level.dart';
 export 'src/link.dart';
-export 'src/mason_logger.dart' show Logger, Progress;
+export 'src/mason_logger.dart'
+    show Logger, Progress, ProgressAnimation, ProgressOptions;

--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -62,7 +62,7 @@ class Logger {
         message,
         _stdout,
         level,
-        progressAnimation: progressAnimation,
+        progressAnimation,
       );
 
   /// Writes error message to stderr.

--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -13,14 +13,14 @@ class Logger {
   /// {@macro logger}
   Logger({
     this.level = Level.info,
-    this.progressAnimation,
+    this.progressOptions = const ProgressOptions(),
   });
 
   /// The current log level for this logger.
   Level level;
 
-  /// The current progress animation for this logger.
-  List<String>? progressAnimation;
+  /// The progress options for the logger instance.
+  ProgressOptions progressOptions;
 
   final _queue = <String?>[];
   final io.IOOverrides? _overrides = io.IOOverrides.current;
@@ -59,17 +59,16 @@ class Logger {
   void delayed(String? message) => _queue.add(message);
 
   /// Writes progress message to stdout.
-  /// Provide a animation list via [progressAnimation].
-  Progress progress(
-    String message, {
-    List<String>? progressAnimation,
-  }) =>
-      Progress._(
-        message,
-        _stdout,
-        level,
-        progressAnimation ?? this.progressAnimation,
-      );
+  /// Optionally provide [options] to override the current
+  /// [ProgressOptions] for the generated [Progress].
+  Progress progress(String message, {ProgressOptions? options}) {
+    return Progress._(
+      message,
+      _stdout,
+      level,
+      options: options ?? progressOptions,
+    );
+  }
 
   /// Writes error message to stderr.
   void err(String? message) {

--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -53,7 +53,17 @@ class Logger {
   void delayed(String? message) => _queue.add(message);
 
   /// Writes progress message to stdout.
-  Progress progress(String message) => Progress._(message, _stdout, level);
+  /// Provide a animation list via [progressAnimation].
+  Progress progress(
+    String message, {
+    List<String>? progressAnimation,
+  }) =>
+      Progress._(
+        message,
+        _stdout,
+        level,
+        progressAnimation: progressAnimation,
+      );
 
   /// Writes error message to stderr.
   void err(String? message) {

--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -11,10 +11,16 @@ part 'progress.dart';
 /// {@endtemplate}
 class Logger {
   /// {@macro logger}
-  Logger({this.level = Level.info});
+  Logger({
+    this.level = Level.info,
+    this.progressAnimation,
+  });
 
   /// The current log level for this logger.
   Level level;
+
+  /// The current progress animation for this logger.
+  List<String>? progressAnimation;
 
   final _queue = <String?>[];
   final io.IOOverrides? _overrides = io.IOOverrides.current;
@@ -62,7 +68,7 @@ class Logger {
         message,
         _stdout,
         level,
-        progressAnimation,
+        progressAnimation ?? this.progressAnimation,
       );
 
   /// Writes error message to stderr.

--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -8,15 +8,17 @@ class Progress {
   Progress._(
     this._message,
     this._stdout,
-    this._level,
-  ) : _stopwatch = Stopwatch() {
+    this._level, {
+    List<String>? progressAnimation,
+  })  : _stopwatch = Stopwatch(),
+        _progressAnimation = progressAnimation ?? _defaultProgressAnimation {
     _stopwatch
       ..reset()
       ..start();
     _timer = Timer.periodic(const Duration(milliseconds: 80), _onTick);
   }
 
-  static const List<String> _progressAnimation = [
+  static const List<String> _defaultProgressAnimation = [
     '⠋',
     '⠙',
     '⠹',
@@ -28,6 +30,8 @@ class Progress {
     '⠇',
     '⠏'
   ];
+
+  final List<String> _progressAnimation;
 
   final io.Stdout _stdout;
 

--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -8,9 +8,9 @@ class Progress {
   Progress._(
     this._message,
     this._stdout,
-    this._level, {
+    this._level,
     List<String>? progressAnimation,
-  })  : _stopwatch = Stopwatch(),
+  )   : _stopwatch = Stopwatch(),
         _progressAnimation = progressAnimation ?? _defaultProgressAnimation {
     _stopwatch
       ..reset()

--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -1,24 +1,25 @@
 part of 'mason_logger.dart';
 
-/// {@template progress}
-/// A class that can be used to display progress information to the user.
+/// {@template progress_options}
+/// An object containing configuration for a [Progress] instance.
 /// {@endtemplate}
-class Progress {
-  /// {@macro progress}
-  Progress._(
-    this._message,
-    this._stdout,
-    this._level,
-    List<String>? progressAnimation,
-  )   : _stopwatch = Stopwatch(),
-        _progressAnimation = progressAnimation ?? _defaultProgressAnimation {
-    _stopwatch
-      ..reset()
-      ..start();
-    _timer = Timer.periodic(const Duration(milliseconds: 80), _onTick);
-  }
+class ProgressOptions {
+  /// {@macro progress_options}
+  const ProgressOptions({this.animation = const ProgressAnimation()});
 
-  static const List<String> _defaultProgressAnimation = [
+  /// The progress animation configuration.
+  final ProgressAnimation animation;
+}
+
+/// {@template progress_animation}
+/// An object which contains configuration for the animation
+/// of a [Progress] instance.
+/// {@endtemplate}
+class ProgressAnimation {
+  /// {@macro progress_animation}
+  const ProgressAnimation({this.frames = _defaultProgressAnimationFrames});
+
+  static const List<String> _defaultProgressAnimationFrames = [
     '⠋',
     '⠙',
     '⠹',
@@ -31,7 +32,29 @@ class Progress {
     '⠏'
   ];
 
-  final List<String> _progressAnimation;
+  /// A list of animation frames.
+  final List<String> frames;
+}
+
+/// {@template progress}
+/// A class that can be used to display progress information to the user.
+/// {@endtemplate}
+class Progress {
+  /// {@macro progress}
+  Progress._(
+    this._message,
+    this._stdout,
+    this._level, {
+    ProgressOptions options = const ProgressOptions(),
+  })  : _stopwatch = Stopwatch(),
+        _options = options {
+    _stopwatch
+      ..reset()
+      ..start();
+    _timer = Timer.periodic(const Duration(milliseconds: 80), _onTick);
+  }
+
+  final ProgressOptions _options;
 
   final io.Stdout _stdout;
 
@@ -77,7 +100,8 @@ class Progress {
 
   void _onTick(Timer _) {
     _index++;
-    final char = _progressAnimation[_index % _progressAnimation.length];
+    final frames = _options.animation.frames;
+    final char = frames[_index % frames.length];
     _write(
       '''${lightGreen.wrap('$_clearMessageLength$char')} $_message... $_time''',
     );

--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -17,9 +17,9 @@ class ProgressOptions {
 /// {@endtemplate}
 class ProgressAnimation {
   /// {@macro progress_animation}
-  const ProgressAnimation({this.frames = _defaultProgressAnimationFrames});
+  const ProgressAnimation({this.frames = _defaultFrames});
 
-  static const List<String> _defaultProgressAnimationFrames = [
+  static const _defaultFrames = [
     '⠋',
     '⠙',
     '⠹',

--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -101,10 +101,11 @@ class Progress {
   void _onTick(Timer _) {
     _index++;
     final frames = _options.animation.frames;
-    final char = frames[_index % frames.length];
-    _write(
-      '''${lightGreen.wrap('$_clearMessageLength$char')} $_message... $_time''',
-    );
+    final char = frames.isEmpty ? '' : frames[_index % frames.length];
+    final prefix = char.isEmpty
+        ? _clearMessageLength
+        : '${lightGreen.wrap('$_clearMessageLength$char')} ';
+    _write('$prefix$_message... $_time');
   }
 
   void _write(Object? object) {

--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -32,7 +32,7 @@ class ProgressAnimation {
     '⠏'
   ];
 
-  /// A list of animation frames.
+  /// The list of animation frames.
   final List<String> frames;
 }
 

--- a/packages/mason_logger/test/src/mason_logger_test.dart
+++ b/packages/mason_logger/test/src/mason_logger_test.dart
@@ -31,12 +31,29 @@ void main() {
       });
     });
 
-    group('progressAnimation', () {
-      test('is mutable', () {
+    group('progressOptions', () {
+      test('are set by default', () {
+        expect(Logger().progressOptions, equals(const ProgressOptions()));
+      });
+
+      test('can be injected via constructor', () {
+        const customProgressOptions = ProgressOptions(
+          animation: ProgressAnimation(frames: []),
+        );
+        expect(
+          Logger(progressOptions: customProgressOptions).progressOptions,
+          equals(customProgressOptions),
+        );
+      });
+
+      test('are mutable', () {
         final logger = Logger();
-        expect(logger.progressAnimation, equals(null));
-        logger.progressAnimation = ['a', 'b', 'c'];
-        expect(logger.progressAnimation, equals(['a', 'b', 'c']));
+        const customProgressOptions = ProgressOptions(
+          animation: ProgressAnimation(frames: []),
+        );
+        expect(logger.progressOptions, equals(const ProgressOptions()));
+        logger.progressOptions = customProgressOptions;
+        expect(logger.progressOptions, equals(customProgressOptions));
       });
     });
 
@@ -521,72 +538,26 @@ void main() {
           () async {
             const time = '(0.Xs)';
             const message = 'test message';
-            final done = Logger().progress(
-              message,
-              progressAnimation: [
-                'a',
-                'b',
-                'c',
-              ],
+            const progressOptions = ProgressOptions(
+              animation: ProgressAnimation(frames: ['+', 'x', '*']),
             );
+            final done = Logger().progress(message, options: progressOptions);
             await Future<void>.delayed(const Duration(milliseconds: 400));
             done.complete();
             verifyInOrder([
               () {
                 stdout.write(
-                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}a')} $message... ${darkGray.wrap('(0.1s)')}''',
+                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}+')} $message... ${darkGray.wrap('(0.1s)')}''',
                 );
               },
               () {
                 stdout.write(
-                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}b')} $message... ${darkGray.wrap('(0.2s)')}''',
+                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}x')} $message... ${darkGray.wrap('(0.2s)')}''',
                 );
               },
               () {
                 stdout.write(
-                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}c')} $message... ${darkGray.wrap('(0.3s)')}''',
-                );
-              },
-              () {
-                stdout.write(
-                  '''\b${'\b' * (message.length + 4 + time.length)}\u001b[2K${lightGreen.wrap('✓')} $message ${darkGray.wrap('(0.4s)')}\n''',
-                );
-              },
-            ]);
-          },
-          stdout: () => stdout,
-          stdin: () => stdin,
-        );
-      });
-
-      test('writes loggers progress animation to stdout', () async {
-        await IOOverrides.runZoned(
-          () async {
-            const time = '(0.Xs)';
-            const message = 'test message';
-            final done = Logger(
-              progressAnimation: [
-                'a',
-                'b',
-                'c',
-              ],
-            ).progress(message);
-            await Future<void>.delayed(const Duration(milliseconds: 400));
-            done.complete();
-            verifyInOrder([
-              () {
-                stdout.write(
-                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}a')} $message... ${darkGray.wrap('(0.1s)')}''',
-                );
-              },
-              () {
-                stdout.write(
-                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}b')} $message... ${darkGray.wrap('(0.2s)')}''',
-                );
-              },
-              () {
-                stdout.write(
-                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}c')} $message... ${darkGray.wrap('(0.3s)')}''',
+                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}*')} $message... ${darkGray.wrap('(0.3s)')}''',
                 );
               },
               () {

--- a/packages/mason_logger/test/src/mason_logger_test.dart
+++ b/packages/mason_logger/test/src/mason_logger_test.dart
@@ -506,6 +506,49 @@ void main() {
           stdin: () => stdin,
         );
       });
+
+      test('writes custom progress animation to stdout', () async {
+        await IOOverrides.runZoned(
+          () async {
+            const time = '(0.Xs)';
+            const message = 'test message';
+            final done = Logger().progress(
+              message,
+              progressAnimation: [
+                'a',
+                'b',
+                'c',
+              ],
+            );
+            await Future<void>.delayed(const Duration(milliseconds: 400));
+            done.complete();
+            verifyInOrder([
+              () {
+                stdout.write(
+                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}a')} $message... ${darkGray.wrap('(0.1s)')}''',
+                );
+              },
+              () {
+                stdout.write(
+                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}b')} $message... ${darkGray.wrap('(0.2s)')}''',
+                );
+              },
+              () {
+                stdout.write(
+                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}c')} $message... ${darkGray.wrap('(0.3s)')}''',
+                );
+              },
+              () {
+                stdout.write(
+                  '''\b${'\b' * (message.length + 4 + time.length)}\u001b[2K${lightGreen.wrap('✓')} $message ${darkGray.wrap('(0.4s)')}\n''',
+                );
+              },
+            ]);
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
     });
 
     group('.chooseAny', () {

--- a/packages/mason_logger/test/src/mason_logger_test.dart
+++ b/packages/mason_logger/test/src/mason_logger_test.dart
@@ -532,45 +532,6 @@ void main() {
           stdin: () => stdin,
         );
       });
-
-      test('writes custom progress animation to stdout', () async {
-        await IOOverrides.runZoned(
-          () async {
-            const time = '(0.Xs)';
-            const message = 'test message';
-            const progressOptions = ProgressOptions(
-              animation: ProgressAnimation(frames: ['+', 'x', '*']),
-            );
-            final done = Logger().progress(message, options: progressOptions);
-            await Future<void>.delayed(const Duration(milliseconds: 400));
-            done.complete();
-            verifyInOrder([
-              () {
-                stdout.write(
-                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}+')} $message... ${darkGray.wrap('(0.1s)')}''',
-                );
-              },
-              () {
-                stdout.write(
-                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}x')} $message... ${darkGray.wrap('(0.2s)')}''',
-                );
-              },
-              () {
-                stdout.write(
-                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}*')} $message... ${darkGray.wrap('(0.3s)')}''',
-                );
-              },
-              () {
-                stdout.write(
-                  '''\b${'\b' * (message.length + 4 + time.length)}\u001b[2K${lightGreen.wrap('✓')} $message ${darkGray.wrap('(0.4s)')}\n''',
-                );
-              },
-            ]);
-          },
-          stdout: () => stdout,
-          stdin: () => stdin,
-        );
-      });
     });
 
     group('.chooseAny', () {

--- a/packages/mason_logger/test/src/mason_logger_test.dart
+++ b/packages/mason_logger/test/src/mason_logger_test.dart
@@ -31,6 +31,15 @@ void main() {
       });
     });
 
+    group('progressAnimation', () {
+      test('is mutable', () {
+        final logger = Logger();
+        expect(logger.progressAnimation, equals(null));
+        logger.progressAnimation = ['a', 'b', 'c'];
+        expect(logger.progressAnimation, equals(['a', 'b', 'c']));
+      });
+    });
+
     group('.write', () {
       test('writes to stdout', () {
         IOOverrides.runZoned(
@@ -520,6 +529,48 @@ void main() {
                 'c',
               ],
             );
+            await Future<void>.delayed(const Duration(milliseconds: 400));
+            done.complete();
+            verifyInOrder([
+              () {
+                stdout.write(
+                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}a')} $message... ${darkGray.wrap('(0.1s)')}''',
+                );
+              },
+              () {
+                stdout.write(
+                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}b')} $message... ${darkGray.wrap('(0.2s)')}''',
+                );
+              },
+              () {
+                stdout.write(
+                  '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}c')} $message... ${darkGray.wrap('(0.3s)')}''',
+                );
+              },
+              () {
+                stdout.write(
+                  '''\b${'\b' * (message.length + 4 + time.length)}\u001b[2K${lightGreen.wrap('✓')} $message ${darkGray.wrap('(0.4s)')}\n''',
+                );
+              },
+            ]);
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
+
+      test('writes loggers progress animation to stdout', () async {
+        await IOOverrides.runZoned(
+          () async {
+            const time = '(0.Xs)';
+            const message = 'test message';
+            final done = Logger(
+              progressAnimation: [
+                'a',
+                'b',
+                'c',
+              ],
+            ).progress(message);
             await Future<void>.delayed(const Duration(milliseconds: 400));
             done.complete();
             verifyInOrder([


### PR DESCRIPTION
## Status

**READY**

## Description

This PR addresses the open issue #451 

I have given the .progress API an optional value where developers can pass through their own array of strings they want to animate through.

If nothing is given, we will fall back to the original progressAnimation. 

Note: If the developer passes an empty array, this will break the logger (IntegerDivisionByZeroException). Do we want to check for this? Or should the developer just not pass through an empty array?

Let me know if there's anything that needs changing!

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
