### PR TITLE
fix(vscode): assume enum default prompt value

### DIFF
--- a/extensions/vscode/src/commands/make-brick.ts
+++ b/extensions/vscode/src/commands/make-brick.ts
@@ -203,7 +203,7 @@ const promptForEnum = async (
   items: string[]
 ): Promise<string | undefined> => {
   if (_.isNil(_default) && !_.isEmpty(items)) {
-    _default = items[0]
+    _default = items[0];
   }
 
   return vscode.window.showQuickPick(

--- a/extensions/vscode/src/commands/make-brick.ts
+++ b/extensions/vscode/src/commands/make-brick.ts
@@ -202,6 +202,10 @@ const promptForEnum = async (
   _default: string,
   items: string[]
 ): Promise<string | undefined> => {
+  if (_.isNil(_default) && !_.isEmpty(items)) {
+    _default = items[0]
+  }
+
   return vscode.window.showQuickPick(
     [_default, ...items.filter((item) => item !== _default)],
     {


### PR DESCRIPTION
## Status

**READY**

## Description

Right now, if there's an enum variable declaration in your `brick.yaml` but there's no default value specified, VSCode extension `make*Command` execution breaks without producing any output. If there's no default, the extension should pick up first value from `values` as the default, similarly to what the CLI does in this situation.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
