### PR TITLE
feat(logger): adds support for milliseconds on progress duration

### DIFF
--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -92,14 +92,12 @@ class Progress {
   String get _clearLn => '$_clearMessageLength\u001b[2K';
 
   String get _time {
-    final time = _stopwatch.elapsed.inMilliseconds;
-    final displayInMilliseconds = time < 100;
-    final elapsed = displayInMilliseconds ? time : time / 1000;
-    final unit = displayInMilliseconds ? 'ms' : 's';
+    final elapsedTime = _stopwatch.elapsed.inMilliseconds;
+    final displayInMilliseconds = elapsedTime < 100;
+    final time = displayInMilliseconds ? elapsedTime : elapsedTime / 1000;
     final formattedTime = displayInMilliseconds
-        ? '${elapsed.toString()}$unit'
-        : '${elapsed.toStringAsFixed(1)}$unit';
-
-    return '''${darkGray.wrap('($formattedTime)')}''';
+        ? '${time.toString()}ms'
+        : '${time.toStringAsFixed(1)}s';
+    return '${darkGray.wrap('($formattedTime)')}';
   }
 }

--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -92,7 +92,14 @@ class Progress {
   String get _clearLn => '$_clearMessageLength\u001b[2K';
 
   String get _time {
-    final elapsed = _stopwatch.elapsed.inMilliseconds / 1000.0;
-    return '''${darkGray.wrap('(${elapsed.toStringAsFixed(1)}s)')}''';
+    final time = _stopwatch.elapsed.inMilliseconds;
+    final displayInMilliseconds = time < 100;
+    final elapsed = displayInMilliseconds ? time : time/1000;
+    final unit = displayInMilliseconds ? 'ms' : 's';
+    final formattedTime = displayInMilliseconds
+      ? '${elapsed.toString()}$unit' 
+      : '${elapsed.toStringAsFixed(1)}$unit';
+    
+    return '''${darkGray.wrap('($formattedTime)')}''';
   }
 }

--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -94,12 +94,12 @@ class Progress {
   String get _time {
     final time = _stopwatch.elapsed.inMilliseconds;
     final displayInMilliseconds = time < 100;
-    final elapsed = displayInMilliseconds ? time : time/1000;
+    final elapsed = displayInMilliseconds ? time : time / 1000;
     final unit = displayInMilliseconds ? 'ms' : 's';
     final formattedTime = displayInMilliseconds
-      ? '${elapsed.toString()}$unit' 
-      : '${elapsed.toStringAsFixed(1)}$unit';
-    
+        ? '${elapsed.toString()}$unit'
+        : '${elapsed.toStringAsFixed(1)}$unit';
+
     return '''${darkGray.wrap('($formattedTime)')}''';
   }
 }

--- a/packages/mason_logger/test/src/progress_test.dart
+++ b/packages/mason_logger/test/src/progress_test.dart
@@ -17,6 +17,26 @@ void main() {
       stdout = MockStdout();
     });
 
+    test('writes ms when elapsed time is less than 0.1s', () async {
+      await runZoned(
+        () async {
+          await IOOverrides.runZoned(
+            () async {
+              const message = 'test message';
+              final progress = Logger().progress(message);
+              await Future<void>.delayed(const Duration(milliseconds: 10));
+              progress.complete();
+              verify(
+                () => stdout.write(any(that: matches(RegExp(r'\(\d\dms\)')))),
+              ).called(1);
+            },
+            stdout: () => stdout,
+          );
+        },
+        zoneValues: {AnsiCode: true},
+      );
+    });
+
     group('.complete', () {
       test('writes lines to stdout', () async {
         await runZoned(
@@ -31,7 +51,11 @@ void main() {
                 verify(
                   () {
                     stdout.write(
-                      '''[92m⠙[0m $message... [90m$time[0m''',
+                      any(
+                        that: contains(
+                          '''[92m⠙[0m $message... [90m''',
+                        ),
+                      ),
                     );
                   },
                 ).called(1);
@@ -85,7 +109,11 @@ void main() {
                 verify(
                   () {
                     stdout.write(
-                      '''[92m⠙[0m $message... [90m$time[0m''',
+                      any(
+                        that: contains(
+                          '''[92m⠙[0m $message... [90m''',
+                        ),
+                      ),
                     );
                   },
                 ).called(1);
@@ -139,7 +167,11 @@ void main() {
                 verify(
                   () {
                     stdout.write(
-                      '''[92m⠙[0m $message... [90m$time[0m''',
+                      any(
+                        that: contains(
+                          '''[92m⠙[0m $message... [90m''',
+                        ),
+                      ),
                     );
                   },
                 ).called(1);
@@ -183,7 +215,6 @@ void main() {
           () async {
             await IOOverrides.runZoned(
               () async {
-                const time = '(0.1s)';
                 const message = 'test message';
                 final progress = Logger().progress(message);
                 await Future<void>.delayed(const Duration(milliseconds: 100));
@@ -191,7 +222,11 @@ void main() {
                 verify(
                   () {
                     stdout.write(
-                      '''[92m⠙[0m $message... [90m$time[0m''',
+                      any(
+                        that: contains(
+                          '''[92m⠙[0m $message... [90m''',
+                        ),
+                      ),
                     );
                   },
                 ).called(1);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Displays milliseconds appropriately when `progress` takes less than 100 milliseconds to complete like in this picture:
<img width="430" alt="image" src="https://user-images.githubusercontent.com/3236791/183272891-1ff4632e-8f24-412c-99b7-13d405fa63e1.png">

**Currently returns `0.0s` if less than 100ms.**

This is the sample code I've used in dart pad. 
<img width="752" alt="image" src="https://user-images.githubusercontent.com/3236791/183272917-d625839e-f4e4-453a-b0b7-9d3de3880b15.png">

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
