### PR TITLE
feat(mason_logger): generic support for `chooseOne` and `chooseAny`

### DIFF
--- a/packages/mason_cli/test/commands/make_test.dart
+++ b/packages/mason_cli/test/commands/make_test.dart
@@ -624,7 +624,7 @@ bricks:
         () => logger.chooseOne(
           any(),
           choices: any(named: 'choices'),
-          defaultValue: any(named: 'defaultValue'),
+          defaultValue: any<String>(named: 'defaultValue'),
         ),
       ).thenReturn('blue');
       final result = await commandRunner.run(['make', 'favorite_color']);

--- a/packages/mason_cli/test/commands/make_test.dart
+++ b/packages/mason_cli/test/commands/make_test.dart
@@ -621,7 +621,7 @@ bricks:
       )..createSync(recursive: true);
       Directory.current = testDir.path;
       when(
-        () => logger.chooseOne(
+        () => logger.chooseOne<String>(
           any(),
           choices: any(named: 'choices'),
           defaultValue: any<String>(named: 'defaultValue'),
@@ -680,7 +680,7 @@ bricks:
       )..createSync(recursive: true);
       Directory.current = testDir.path;
       when(
-        () => logger.chooseAny(
+        () => logger.chooseAny<String>(
           any(),
           choices: any(named: 'choices'),
           defaultValues: any(named: 'defaultValues'),

--- a/packages/mason_cli/test/commands/make_test.dart
+++ b/packages/mason_cli/test/commands/make_test.dart
@@ -624,7 +624,7 @@ bricks:
         () => logger.chooseOne<String>(
           any(),
           choices: any(named: 'choices'),
-          defaultValue: any<String>(named: 'defaultValue'),
+          defaultValue: any(named: 'defaultValue'),
         ),
       ).thenReturn('blue');
       final result = await commandRunner.run(['make', 'favorite_color']);

--- a/packages/mason_logger/example/main.dart
+++ b/packages/mason_logger/example/main.dart
@@ -60,22 +60,18 @@ Future<void> main() async {
   );
   logger.info('To learn more, visit the $repoLink.');
 
-  final shape = logger.chooseOne(
+  final shape = logger.chooseOne<Shape>(
     'What is your favorite shape?',
     choices: Shape.values,
-    display: (Shape shape) {
-      return 'Is it a ${shape.name}?';
-    },
+    display: (shape) => 'Is it a ${shape.name}?',
   );
   logger.info('You chose $shape!');
 
-  final shapes = logger.chooseAny(
+  final shapes = logger.chooseAny<Shape>(
     'Or did you want to choose multiples?',
     choices: Shape.values,
     defaultValues: [shape],
-    display: (Shape shape) {
-      return 'Is it a ${shape.name}?';
-    },
+    display: (shape) => 'Is it a ${shape.name}?',
   );
   logger.info('You chose the following shapes: $shapes!');
 }

--- a/packages/mason_logger/example/main.dart
+++ b/packages/mason_logger/example/main.dart
@@ -74,7 +74,7 @@ Future<void> main() async {
     choices: Shape.values,
     defaultValues: [shape],
     display: (Shape shape) {
-      return 'Is it a ${shape.toString().split('.').last}?';
+      return 'Is it a ${shape.name}?';
     },
   );
   logger.info('You chose the following shapes: $shapes!');

--- a/packages/mason_logger/example/main.dart
+++ b/packages/mason_logger/example/main.dart
@@ -1,5 +1,12 @@
 import 'package:mason_logger/mason_logger.dart';
 
+enum Shape {
+  Square,
+  Circle,
+  Triangle,
+  Diamond,
+}
+
 Future<void> main() async {
   final logger = Logger(level: Level.verbose)
     ..info('info')
@@ -52,4 +59,23 @@ Future<void> main() async {
     uri: Uri.parse('https://github.com/felangel/mason'),
   );
   logger.info('To learn more, visit the $repoLink.');
+
+  final shape = logger.chooseOne(
+    'What is your favorite shape?',
+    choices: Shape.values,
+    display: (Shape shape) {
+      return 'Is it a ${shape.toString().split('.').last}?';
+    },
+  );
+  logger.info('You chose $shape!');
+
+  final shapes = logger.chooseAny(
+    'Or did you want to choose multiples?',
+    choices: Shape.values,
+    defaultValues: [shape],
+    display: (Shape shape) {
+      return 'Is it a ${shape.toString().split('.').last}?';
+    },
+  );
+  logger.info('You chose the following shapes: $shapes!');
 }

--- a/packages/mason_logger/example/main.dart
+++ b/packages/mason_logger/example/main.dart
@@ -1,10 +1,10 @@
 import 'package:mason_logger/mason_logger.dart';
 
 enum Shape {
-  Square,
-  Circle,
-  Triangle,
-  Diamond,
+  square,
+  circle,
+  triangle,
+  diamond,
 }
 
 Future<void> main() async {

--- a/packages/mason_logger/example/main.dart
+++ b/packages/mason_logger/example/main.dart
@@ -64,7 +64,7 @@ Future<void> main() async {
     'What is your favorite shape?',
     choices: Shape.values,
     display: (Shape shape) {
-      return 'Is it a ${shape.toString().split('.').last}?';
+      return 'Is it a ${shape.name}?';
     },
   );
   logger.info('You chose $shape!');

--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -129,12 +129,15 @@ class Logger {
   ///
   /// An optional [defaultValue] can be specified.
   /// The [defaultValue] must be one of the provided [choices].
-  String chooseOne(
+  T chooseOne<T>(
     String? message, {
-    required List<String> choices,
-    String? defaultValue,
+    required List<T> choices,
+    T? defaultValue,
+    String Function(T)? display,
   }) {
-    final hasDefault = defaultValue != null && defaultValue.isNotEmpty;
+    final _display = display ?? (value) => '$value';
+    final hasDefault =
+        defaultValue != null && _display(defaultValue).isNotEmpty;
     var index = hasDefault ? choices.indexOf(defaultValue) : 0;
 
     void writeChoices() {
@@ -151,11 +154,11 @@ class Logger {
         if (isCurrent) {
           _stdout
             ..write(green.wrap('❯'))
-            ..write(' $checkBox  ${lightCyan.wrap(choice)}');
+            ..write(' $checkBox  ${lightCyan.wrap(_display(choice))}');
         } else {
           _stdout
             ..write(' ')
-            ..write(' $checkBox  $choice');
+            ..write(' $checkBox  ${_display(choice)}');
         }
         if (choices.last != choice) {
           _stdout.write('\n');
@@ -170,8 +173,8 @@ class Logger {
     writeChoices();
 
     final event = <int>[];
-    var result = '';
-    while (result.isEmpty) {
+    T? result;
+    while (result == null) {
       final byte = _stdin.readByteSync();
       if (event.length == 3) event.clear();
       event.add(byte);
@@ -194,7 +197,7 @@ class Logger {
           // show cursor
           ..write('\x1b[?25h')
           ..write('$message ')
-          ..writeln(styleDim.wrap(lightCyan.wrap(choices[index])));
+          ..writeln(styleDim.wrap(lightCyan.wrap(_display(choices[index]))));
 
         result = choices[index];
         break;
@@ -205,7 +208,7 @@ class Logger {
       writeChoices();
     }
 
-    return result;
+    return result!;
   }
 
   /// Prompts user with [message] to choose zero or more values
@@ -213,11 +216,13 @@ class Logger {
   ///
   /// An optional list of [defaultValues] can be specified.
   /// The [defaultValues] must be one of the provided [choices].
-  List<String> chooseAny(
+  List<T> chooseAny<T>(
     String? message, {
-    required List<String> choices,
-    List<String>? defaultValues,
+    required List<T> choices,
+    List<T>? defaultValues,
+    String Function(T)? display,
   }) {
+    final _display = display ?? (value) => '$value';
     final hasDefaults = defaultValues != null && defaultValues.isNotEmpty;
     final selections = hasDefaults
         ? defaultValues.map((value) => choices.indexOf(value)).toSet()
@@ -240,11 +245,11 @@ class Logger {
         if (isCurrent) {
           _stdout
             ..write(green.wrap('❯'))
-            ..write(' $checkBox  ${lightCyan.wrap(choice)}');
+            ..write(' $checkBox  ${lightCyan.wrap(_display(choice))}');
         } else {
           _stdout
             ..write(' ')
-            ..write(' $checkBox  $choice');
+            ..write(' $checkBox  ${_display(choice)}');
         }
         if (choices.last != choice) {
           _stdout.write('\n');
@@ -259,7 +264,7 @@ class Logger {
     writeChoices();
 
     final event = <int>[];
-    List<String>? results;
+    List<T>? results;
     while (results == null) {
       final byte = _stdin.readByteSync();
       if (event.length == 3) event.clear();

--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -148,7 +148,7 @@ class Logger {
     String? message, {
     required List<T> choices,
     T? defaultValue,
-    String Function(T)? display,
+    String Function(T choice)? display,
   }) {
     final _display = display ?? (value) => '$value';
     final hasDefault =
@@ -235,7 +235,7 @@ class Logger {
     String? message, {
     required List<T> choices,
     List<T>? defaultValues,
-    String Function(T)? display,
+    String Function(T choice)? display,
   }) {
     final _display = display ?? (value) => '$value';
     final hasDefaults = defaultValues != null && defaultValues.isNotEmpty;

--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -144,7 +144,7 @@ class Logger {
   ///
   /// An optional [defaultValue] can be specified.
   /// The [defaultValue] must be one of the provided [choices].
-  T chooseOne<T>(
+  T chooseOne<T extends Object?>(
     String? message, {
     required List<T> choices,
     T? defaultValue,
@@ -231,7 +231,7 @@ class Logger {
   ///
   /// An optional list of [defaultValues] can be specified.
   /// The [defaultValues] must be one of the provided [choices].
-  List<T> chooseAny<T>(
+  List<T> chooseAny<T extends Object?>(
     String? message, {
     required List<T> choices,
     List<T>? defaultValues,

--- a/packages/mason_logger/test/src/mason_logger_test.dart
+++ b/packages/mason_logger/test/src/mason_logger_test.dart
@@ -878,6 +878,38 @@ void main() {
           stdin: () => stdin,
         );
       });
+
+      test('converts list to a preferred display', () {
+        IOOverrides.runZoned(
+          () {
+            const message = 'test message';
+            when(() => stdin.readByteSync()).thenReturn(10);
+            final actual = Logger().chooseAny<Map<String, String>>(
+              message,
+              choices: [
+                {'key': 'a'},
+                {'key': 'b'},
+                {'key': 'c'},
+              ],
+              display: (data) => 'Key: ${data['key']}',
+            );
+            expect(actual, isEmpty);
+            verifyInOrder([
+              () => stdout.write('\x1b7'),
+              () => stdout.write('\x1b[?25l'),
+              () => stdout.writeln(message),
+              () => stdout.write(green.wrap('❯')),
+              () => stdout.write(' ◯  ${lightCyan.wrap('Key: a')}'),
+              () => stdout.write(' '),
+              () => stdout.write(' ◯  Key: b'),
+              () => stdout.write(' '),
+              () => stdout.write(' ◯  Key: c'),
+            ]);
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
     });
 
     group('.chooseOne', () {
@@ -1220,6 +1252,41 @@ void main() {
               () => stdout.write(' ◯  b'),
               () => stdout.write(' '),
               () => stdout.write(' ◯  c'),
+            ]);
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
+
+      test('converts list to a preferred display', () {
+        IOOverrides.runZoned(
+          () {
+            const message = 'test message';
+            const expected = {'key': 'a'};
+            when(() => stdin.readByteSync()).thenReturn(10);
+            final actual = Logger().chooseOne<Map<String, String>>(
+              message,
+              choices: [
+                {'key': 'a'},
+                {'key': 'b'},
+                {'key': 'c'},
+              ],
+              display: (data) => 'Key: ${data['key']}',
+            );
+            expect(actual, equals(expected));
+            verifyInOrder([
+              () => stdout.write('\x1b7'),
+              () => stdout.write('\x1b[?25l'),
+              () => stdout.writeln(message),
+              () => stdout.write(green.wrap('❯')),
+              () => stdout.write(
+                    ' ${lightCyan.wrap('◉')}  ${lightCyan.wrap('Key: a')}',
+                  ),
+              () => stdout.write(' '),
+              () => stdout.write(' ◯  Key: b'),
+              () => stdout.write(' '),
+              () => stdout.write(' ◯  Key: c'),
             ]);
           },
           stdout: () => stdout,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Allows for `chooseAny` and `chooseOne` to receive a generic value and map it to string to display.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
