### PR TITLE
fix: progress on android studio terminal

### DIFF
--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -72,7 +72,7 @@ class Progress {
   void complete([String? update]) {
     _stopwatch.stop();
     _write(
-      '''$_clearLn${lightGreen.wrap('✓')} ${update ?? _message} $_time\n''',
+      '''$_clearLine${lightGreen.wrap('✓')} ${update ?? _message} $_time\n''',
     );
     _timer.cancel();
   }
@@ -80,13 +80,13 @@ class Progress {
   /// End the progress and mark it as failed.
   void fail([String? update]) {
     _timer.cancel();
-    _write('$_clearLn${red.wrap('✗')} ${update ?? _message} $_time\n');
+    _write('$_clearLine${red.wrap('✗')} ${update ?? _message} $_time\n');
     _stopwatch.stop();
   }
 
   /// Update the progress message.
   void update(String update) {
-    _write(_clearLn);
+    _write(_clearLine);
     _message = update;
     _onTick(_timer);
   }
@@ -94,31 +94,28 @@ class Progress {
   /// Cancel the progress and remove the written line.
   void cancel() {
     _timer.cancel();
-    _write(_clearLn);
+    _write(_clearLine);
     _stopwatch.stop();
+  }
+
+  String get _clearLine {
+    return '\u001b[2K' // clear current line
+        '\r'; // bring cursor to the start of the current line
   }
 
   void _onTick(Timer _) {
     _index++;
     final frames = _options.animation.frames;
     final char = frames.isEmpty ? '' : frames[_index % frames.length];
-    final prefix = char.isEmpty
-        ? _clearMessageLength
-        : '${lightGreen.wrap('$_clearMessageLength$char')} ';
-    _write('$prefix$_message... $_time');
+    final prefix = char.isEmpty ? char : '${lightGreen.wrap(char)} ';
+
+    _write('$_clearLine$prefix$_message... $_time');
   }
 
-  void _write(Object? object) {
+  void _write(String object) {
     if (_level.index > Level.info.index) return;
     _stdout.write(object);
   }
-
-  String get _clearMessageLength {
-    final length = _message.length + 4 + _time.length;
-    return '\b${'\b' * length}';
-  }
-
-  String get _clearLn => '$_clearMessageLength\u001b[2K';
 
   String get _time {
     final elapsedTime = _stopwatch.elapsed.inMilliseconds;

--- a/packages/mason_logger/test/src/progress_test.dart
+++ b/packages/mason_logger/test/src/progress_test.dart
@@ -122,7 +122,6 @@ void main() {
           () async {
             await IOOverrides.runZoned(
               () async {
-                const time = '(0.1s)';
                 const message = 'test message';
                 final progress = Logger().progress(message);
                 await Future<void>.delayed(const Duration(milliseconds: 100));
@@ -131,17 +130,20 @@ void main() {
                   () {
                     stdout.write(
                       any(
-                        that: contains(
-                          '''[92m⠙[0m $message... [90m''',
+                        that: matches(
+                          RegExp(
+                            r'\[2K\u000D\[92m⠙\[0m test message... \[90m\(8\dms\)\[0m',
+                          ),
                         ),
                       ),
                     );
                   },
                 ).called(1);
+
                 verify(
                   () {
                     stdout.write(
-                      '''[2K[92m✓[0m $message [90m$time[0m\n''',
+                      '''[2K\r[92m✓[0m test message [90m(0.1s)[0m\n''',
                     );
                   },
                 ).called(1);
@@ -173,33 +175,42 @@ void main() {
     });
 
     group('.update', () {
-      test('writes lines to stdout', () async {
+      test('writes lines to stdouta', () async {
         await runZoned(
           () async {
             await IOOverrides.runZoned(
               () async {
                 const message = 'message';
                 const update = 'update';
-                const time = '(0.1s)';
                 final progress = Logger().progress(message);
                 await Future<void>.delayed(const Duration(milliseconds: 100));
                 progress.update(update);
                 await Future<void>.delayed(const Duration(milliseconds: 100));
+
                 verify(
                   () {
                     stdout.write(
                       any(
-                        that: contains(
-                          '''[92m⠙[0m $message... [90m''',
+                        that: matches(
+                          RegExp(
+                            r'\[2K\u000D\[92m⠙\[0m message... \[90m\(8\dms\)\[0m',
+                          ),
                         ),
                       ),
                     );
                   },
                 ).called(1);
+
                 verify(
                   () {
                     stdout.write(
-                      '''[92m⠹[0m $update... [90m$time[0m''',
+                      any(
+                        that: matches(
+                          RegExp(
+                            r'\[2K\u000D\[92m⠹\[0m update... \[90m\(0\.1s\)\[0m',
+                          ),
+                        ),
+                      ),
                     );
                   },
                 ).called(1);
@@ -243,21 +254,25 @@ void main() {
                 final progress = Logger().progress(message);
                 await Future<void>.delayed(const Duration(milliseconds: 100));
                 progress.fail();
+
                 verify(
                   () {
                     stdout.write(
                       any(
-                        that: contains(
-                          '''[92m⠙[0m $message... [90m''',
+                        that: matches(
+                          RegExp(
+                            r'\[2K\u000D\[92m⠙\[0m test message... \[90m\(8\dms\)\[0m',
+                          ),
                         ),
                       ),
                     );
                   },
                 ).called(1);
+
                 verify(
                   () {
                     stdout.write(
-                      '''[2K[31m✗[0m $message [90m$time[0m\n''',
+                      '''[2K\u000D[31m✗[0m $message [90m$time[0m\n''',
                     );
                   },
                 ).called(1);
@@ -302,17 +317,26 @@ void main() {
                   () {
                     stdout.write(
                       any(
-                        that: contains(
-                          '''[92m⠙[0m $message... [90m''',
+                        that: matches(
+                          RegExp(
+                            r'\[2K\u000D\[92m⠙\[0m test message... \[90m\(8\dms\)\[0m',
+                          ),
                         ),
                       ),
                     );
                   },
                 ).called(1);
+
                 verify(
                   () {
                     stdout.write(
-                      '''[2K''',
+                      any(
+                        that: matches(
+                          RegExp(
+                            r'\[2K\u000D',
+                          ),
+                        ),
+                      ),
                     );
                   },
                 ).called(1);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

fix: https://github.com/VeryGoodOpenSource/very_good_cli/issues/499

Most terminals don't consider ANSI sequences as characters to be rem loved from the terminal. And we relied on inserted string lengths that included ANSI sequence characters in its length, causing an excess of backspaces applied on a "clear line" string.

The problem is that IntelliJ IDE's terminals don't block excess backspaces allowing deleting upper lines.

This PR changes the way we clear lines on mason logger's progress in a way we won't rely on string lengths and sequential backspaces.

Instead, we clear lines and then apply `\r` (carriage return) to make the cursor go to the beginning of the line.


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
