### PR TITLE
refactor: use `super.key`

### DIFF
--- a/bricks/widget/__brick__/{{name.snakeCase()}}.dart
+++ b/bricks/widget/__brick__/{{name.snakeCase()}}.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class {{name.pascalCase()}} extends StatelessWidget {
-  const {{name.pascalCase()}}({Key? key}) : super(key: key);
+  const {{name.pascalCase()}}({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/mason_cli/test/fixtures/add/widget/cat.dart
+++ b/packages/mason_cli/test/fixtures/add/widget/cat.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class Cat extends StatelessWidget {
-  const Cat({Key? key}) : super(key: key);
+  const Cat({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/mason_cli/test/fixtures/install/widget/cat.dart
+++ b/packages/mason_cli/test/fixtures/install/widget/cat.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class Cat extends StatelessWidget {
-  const Cat({Key key}) : super(key: key);
+  const Cat({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/mason_cli/test/fixtures/make/widget/my_widget.dart
+++ b/packages/mason_cli/test/fixtures/make/widget/my_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class MyWidget extends StatelessWidget {
-  const MyWidget({Key? key}) : super(key: key);
+  const MyWidget({super.key});
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Status

**READY**

## Description

Removed the super constructor and use `super.key` instead. At your command, sir. 🙌 👑 

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
