### PR TITLE
docs(mason_logger): improve `Progress` documentation

### DIFF
--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -79,7 +79,7 @@ class Progress {
 
   int _index = 0;
 
-  /// End the progress and mark it as a sucessful completion.
+  /// End the progress and mark it as a successful completion.
   ///
   /// See also:
   ///

--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -97,7 +97,7 @@ class Progress {
   ///
   /// See also:
   ///
-  /// * [complete], to end the progress and mark it as a sucessful completion.
+  /// * [complete], to end the progress and mark it as a successful completion.
   /// * [cancel], to cancel the progress entirely and remove the written line.
   void fail([String? update]) {
     _timer?.cancel();

--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -79,7 +79,7 @@ class Progress {
 
   int _index = 0;
 
-  /// End the progress and mark it as sucessfull completed.
+  /// End the progress and mark it as a sucessful completion.
   ///
   /// See also:
   ///
@@ -97,7 +97,7 @@ class Progress {
   ///
   /// See also:
   ///
-  /// * [complete], to end the progress and mark it as a sucessfull completion.
+  /// * [complete], to end the progress and mark it as a sucessful completion.
   /// * [cancel], to cancel the progress entirely and remove the written line.
   void fail([String? update]) {
     _timer?.cancel();

--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -79,7 +79,12 @@ class Progress {
 
   int _index = 0;
 
-  /// End the progress and mark it as completed.
+  /// End the progress and mark it as sucessfull completed.
+  ///
+  /// See also:
+  ///
+  /// * [fail] to end the progress and mark it as failed.
+  /// * [cancel] to cancel the progress entirely and remove the written line.
   void complete([String? update]) {
     _stopwatch.stop();
     _write(
@@ -89,6 +94,11 @@ class Progress {
   }
 
   /// End the progress and mark it as failed.
+  ///
+  /// See also:
+  ///
+  /// * [complete] to end the progress and mark it as a sucessfull completion.
+  /// * [cancel] to cancel the progress entirely and remove the written line.
   void fail([String? update]) {
     _timer?.cancel();
     _write('$_clearLine${red.wrap('✗')} ${update ?? _message} $_time\n');

--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -83,8 +83,8 @@ class Progress {
   ///
   /// See also:
   ///
-  /// * [fail] to end the progress and mark it as failed.
-  /// * [cancel] to cancel the progress entirely and remove the written line.
+  /// * [fail], to end the progress and mark it as failed.
+  /// * [cancel], to cancel the progress entirely and remove the written line.
   void complete([String? update]) {
     _stopwatch.stop();
     _write(
@@ -97,8 +97,8 @@ class Progress {
   ///
   /// See also:
   ///
-  /// * [complete] to end the progress and mark it as a sucessfull completion.
-  /// * [cancel] to cancel the progress entirely and remove the written line.
+  /// * [complete], to end the progress and mark it as a sucessfull completion.
+  /// * [cancel], to cancel the progress entirely and remove the written line.
   void fail([String? update]) {
     _timer?.cancel();
     _write('$_clearLine${red.wrap('✗')} ${update ?? _message} $_time\n');


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Related to #958 

Changes:
- Add pointers to documentation to other similar progress methods

Rationale:
The opposite of `fail` is `success`. However, the logger's API uses `fail` and `complete` instead. I imagine other developers will have the same issue and this addition will improve their experience by outlining this distinction.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
