### PR TITLE
feat(mason): define `BrickIgnore` class

### DIFF
--- a/packages/mason/lib/src/brick_ignore.dart
+++ b/packages/mason/lib/src/brick_ignore.dart
@@ -6,7 +6,6 @@ import 'package:mason/mason.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
-/// {@template brick_ignore}
 /// A file that defines what brick files or directories should be ignored during
 /// bundling.
 ///
@@ -36,7 +35,6 @@ import 'package:path/path.dart' as path;
 /// See also:
 ///
 /// * [createBundle], which creates a [MasonBundle] from a brick directory.
-/// {@endtemplate}
 @internal
 class BrickIgnore {
   BrickIgnore._({

--- a/packages/mason/lib/src/brick_ignore.dart
+++ b/packages/mason/lib/src/brick_ignore.dart
@@ -1,0 +1,93 @@
+import 'dart:collection';
+import 'dart:io';
+
+import 'package:glob/glob.dart';
+import 'package:mason/mason.dart';
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as path;
+
+/// {@template brick_ignore}
+/// A file that is created at the root of the brick to ignore files
+/// and directories during bundling.
+///
+/// Only those directories under `__brick__` can be ignored.
+///
+/// For example, given the following brick directory:
+///
+/// ```txt
+/// __brick__/
+/// ├─ HELLO.md
+/// └─ goodbye.dart
+/// brick.yaml
+/// .brickignore
+/// README.md
+/// ```
+///
+/// And the following `.brickignore` file content:
+///
+/// ```txt
+/// **.md
+/// ```
+///
+/// The `HELLO.md` file will be ignored during bundling, but `goodbye.dart` will
+/// not be ignored. Those other files not under `__brick__` are not bundled,
+/// hence they can not be ignored.
+///
+/// See also:
+///
+/// * [createBundle], which creates a [MasonBundle] from a brick directory.
+/// {@endtemplate}
+@internal
+class BrickIgnore {
+  BrickIgnore._({
+    required Iterable<Glob> globs,
+    required String path,
+    required String brickDirectoryPath,
+  })  : _globs = UnmodifiableListView(globs),
+        _path = path,
+        _brickDirectoryPath = brickDirectoryPath;
+
+  /// Creates a [BrickIgnore] from a [File].
+  factory BrickIgnore.fromFile(File file) {
+    final lines = file.readAsLinesSync();
+    final globs = lines.map(Glob.new);
+
+    final brickDirectoryPath = path.join(file.parent.path, BrickYaml.dir);
+
+    return BrickIgnore._(
+      globs: globs,
+      path: file.path,
+      brickDirectoryPath: brickDirectoryPath,
+    );
+  }
+
+  /// The name of the file to be created at the root of the brick.
+  /// `brick.yaml`
+  static const file = '.brickignore';
+
+  final UnmodifiableListView<Glob> _globs;
+
+  /// The absolute path to the ignore file.
+  final String _path;
+
+  /// The absolute absolute path to the directory where all brick templated
+  /// files are located.
+  ///
+  /// See also:
+  ///
+  /// * [BrickYaml.dir], which is the name of the directory where the templated
+  /// brick files are located.
+  final String _brickDirectoryPath;
+
+  /// Whether or not the [filePath] is ignored.
+  ///
+  /// Immediately returns false if the [filePath] is not within the brick
+  /// directory (`__brick__`). Otherwise, checks if the [filePath] matches
+  /// any of the globs in the ignore file.
+  bool isIgnored(String filePath) {
+    if (!path.isWithin(_brickDirectoryPath, filePath)) return false;
+
+    final relativePath = path.relative(filePath, from: path.dirname(_path));
+    return _globs.any((glob) => glob.matches(relativePath));
+  }
+}

--- a/packages/mason/lib/src/brick_ignore.dart
+++ b/packages/mason/lib/src/brick_ignore.dart
@@ -59,8 +59,7 @@ class BrickIgnore {
     );
   }
 
-  /// The name of the file to be created at the root of the brick.
-  /// `brick.yaml`
+  /// The name of the file to be used as the ignore file.
   static const file = '.brickignore';
 
   final UnmodifiableListView<Glob> _globs;

--- a/packages/mason/lib/src/brick_ignore.dart
+++ b/packages/mason/lib/src/brick_ignore.dart
@@ -48,7 +48,9 @@ class BrickIgnore {
   /// Creates a [BrickIgnore] from a [File].
   factory BrickIgnore.fromFile(File file) {
     final lines = file.readAsLinesSync();
-    final globs = lines.map(Glob.new);
+    final globs = lines.where((line) => !line.startsWith('#')).map(
+          (line) => Glob(line.trim()),
+        );
 
     final brickDirectoryPath = path.join(file.parent.path, BrickYaml.dir);
 

--- a/packages/mason/lib/src/brick_ignore.dart
+++ b/packages/mason/lib/src/brick_ignore.dart
@@ -68,8 +68,8 @@ class BrickIgnore {
   /// The absolute path to the ignore file.
   final String _path;
 
-  /// The absolute absolute path to the directory where all brick templated
-  /// files are located.
+  /// The absolute path to the directory where all brick templated files are
+  /// located.
   ///
   /// See also:
   ///

--- a/packages/mason/lib/src/brick_ignore.dart
+++ b/packages/mason/lib/src/brick_ignore.dart
@@ -48,9 +48,9 @@ class BrickIgnore {
   /// Creates a [BrickIgnore] from a [File].
   factory BrickIgnore.fromFile(File file) {
     final lines = file.readAsLinesSync();
-    final globs = lines.where((line) => !line.startsWith('#')).map(
-          (line) => Glob(line.trim()),
-        );
+    final globs = lines
+        .where((line) => !line.startsWith(_commentCharacter))
+        .map((line) => Glob(line.trim()));
 
     final brickDirectoryPath = path.join(file.parent.path, BrickYaml.dir);
 
@@ -63,6 +63,17 @@ class BrickIgnore {
 
   /// The name of the file to be used as the ignore file.
   static const file = '.brickignore';
+
+  /// The character that indicates a comment in the ignore file.
+  ///
+  /// If the line starts with this character, the line is considered a comment
+  /// and is ignored.
+  ///
+  /// For example:
+  /// ```txt
+  /// # This is a comment
+  /// ```
+  static const _commentCharacter = '#';
 
   final UnmodifiableListView<Glob> _globs;
 

--- a/packages/mason/lib/src/brick_ignore.dart
+++ b/packages/mason/lib/src/brick_ignore.dart
@@ -7,10 +7,10 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
 /// {@template brick_ignore}
-/// A file that is created at the root of the brick to ignore files
-/// and directories during bundling.
+/// A file that defines what brick files or directories should be ignored during
+/// bundling.
 ///
-/// Only those directories under `__brick__` can be ignored.
+/// Only those directories and files under `__brick__` can be ignored.
 ///
 /// For example, given the following brick directory:
 ///

--- a/packages/mason/lib/src/brick_ignore.dart
+++ b/packages/mason/lib/src/brick_ignore.dart
@@ -25,12 +25,16 @@ import 'package:path/path.dart' as path;
 /// And the following `.brickignore` file content:
 ///
 /// ```txt
+/// # Ignore all markdown files
 /// **.md
 /// ```
 ///
 /// The `HELLO.md` file will be ignored during bundling, but `goodbye.dart` will
 /// not be ignored. Those other files not under `__brick__` are not bundled,
 /// hence they can not be ignored.
+///
+/// Note that the ignore file supports comments, which are lines that start
+/// with a `#` character.
 ///
 /// See also:
 ///

--- a/packages/mason/pubspec.yaml
+++ b/packages/mason/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   collection: ^1.15.0
   convert: ^3.1.0
   crypto: ^3.0.1
+  glob: ^2.1.2
   http: '>=0.13.3 <2.0.0'
   json_annotation: ^4.8.1
   mason_logger: ^0.2.11

--- a/packages/mason/test/src/brick_ignore_test.dart
+++ b/packages/mason/test/src/brick_ignore_test.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:mason/src/brick_ignore.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+void main() {
+  group('$BrickIgnore', () {
+    late File brickIgnoreFile;
+
+    setUp(() {
+      final temporaryDirectory = Directory.systemTemp.createTempSync();
+      addTearDown(() => temporaryDirectory.deleteSync(recursive: true));
+
+      brickIgnoreFile =
+          File(path.join(temporaryDirectory.path, BrickIgnore.file))
+            ..createSync();
+    });
+
+    test('fromFile returns normally', () {
+      expect(
+        () => BrickIgnore.fromFile(brickIgnoreFile),
+        returnsNormally,
+      );
+    });
+
+    group('isIgnored', () {
+      test('returns true when the file is ignored', () {
+        brickIgnoreFile.writeAsStringSync('**.md');
+        final brickIgnore = BrickIgnore.fromFile(brickIgnoreFile);
+
+        final ignoredFilePath = path.join(
+          brickIgnoreFile.parent.path,
+          '__brick__',
+          'HELLO.md',
+        );
+
+        expect(
+          brickIgnore.isIgnored(ignoredFilePath),
+          isTrue,
+          reason: '`HELLO.md` is under `__brick__` and is ignored by `**.md`',
+        );
+      });
+
+      test(
+        'returns false when the file to be ignored is not under __brick__',
+        () {
+          brickIgnoreFile.writeAsStringSync('**.md');
+          final brickIgnore = BrickIgnore.fromFile(brickIgnoreFile);
+
+          final ignoredFilePath =
+              path.join(brickIgnoreFile.parent.path, 'HELLO.md');
+
+          expect(
+            brickIgnore.isIgnored(ignoredFilePath),
+            isFalse,
+            reason: '`HELLO.md` is not under `__brick__`',
+          );
+        },
+      );
+
+      test('returns false when the file is not ignored', () {
+        brickIgnoreFile.writeAsStringSync('');
+        final brickIgnore = BrickIgnore.fromFile(brickIgnoreFile);
+
+        final ignoredFilePath = path.join(
+          brickIgnoreFile.parent.path,
+          '__brick__',
+          'HELLO.md',
+        );
+
+        expect(
+          brickIgnore.isIgnored(ignoredFilePath),
+          isFalse,
+          reason: '`HELLO.md` is under `__brick__` and there are no ignores',
+        );
+      });
+    });
+  });
+}

--- a/packages/mason/test/src/brick_ignore_test.dart
+++ b/packages/mason/test/src/brick_ignore_test.dart
@@ -80,6 +80,7 @@ void main() {
         brickIgnoreFile.writeAsStringSync('''
 # Some comment
 **.md
+# **.dart
 ''');
         final brickIgnore = BrickIgnore.fromFile(brickIgnoreFile);
 

--- a/packages/mason/test/src/brick_ignore_test.dart
+++ b/packages/mason/test/src/brick_ignore_test.dart
@@ -98,12 +98,13 @@ void main() {
         final notIgnoredFilePath = path.join(
           brickIgnoreFile.parent.path,
           '__brick__',
-          'main.dart',
+          'goodbye.dart',
         );
         expect(
           brickIgnore.isIgnored(notIgnoredFilePath),
           isFalse,
-          reason: '`main.dart` is under `__brick__` and there are no ignores',
+          reason:
+              '`goodbye.dart` is under `__brick__` and there are no ignores',
         );
       });
     });

--- a/packages/mason/test/src/brick_ignore_test.dart
+++ b/packages/mason/test/src/brick_ignore_test.dart
@@ -75,6 +75,36 @@ void main() {
           reason: '`HELLO.md` is under `__brick__` and there are no ignores',
         );
       });
+
+      test('returns as expected when the file has comments', () {
+        brickIgnoreFile.writeAsStringSync('''
+# Some comment
+**.md
+''');
+        final brickIgnore = BrickIgnore.fromFile(brickIgnoreFile);
+
+        final ignoredFilePath = path.join(
+          brickIgnoreFile.parent.path,
+          '__brick__',
+          'HELLO.md',
+        );
+        expect(
+          brickIgnore.isIgnored(ignoredFilePath),
+          isTrue,
+          reason: '`HELLO.md` is under `__brick__` and is ignored by `**.md`',
+        );
+
+        final notIgnoredFilePath = path.join(
+          brickIgnoreFile.parent.path,
+          '__brick__',
+          'main.dart',
+        );
+        expect(
+          brickIgnore.isIgnored(notIgnoredFilePath),
+          isFalse,
+          reason: '`main.dart` is under `__brick__` and there are no ignores',
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY FOR REVIEW**

## Description

This is a part of https://github.com/felangel/mason/issues/781, yet to be followed by another Pull Request to adjust the bundling logic.

Changes:
- Adds the `glob` dependency
- Adds `BrickIgnore` class
- Defines `BrickIgnore.isIgnored` and `BrickIgnore.fromFile`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
