### PR TITLE
fix(mason_logger): throw `StateError` when prompting with no terminal attached

### DIFF
--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -178,6 +178,9 @@ class Logger {
   /// Prompts user and returns response.
   /// Provide a default value via [defaultValue].
   /// Set [hidden] to `true` if you want to hide user input for sensitive info.
+  ///
+  /// This method requires a terminal to be attached to stdout.
+  /// See https://api.dart.dev/stable/dart-io/Stdout/hasTerminal.html.
   String prompt(String? message, {Object? defaultValue, bool hidden = false}) {
     final hasDefault = defaultValue != null && '$defaultValue'.isNotEmpty;
     final resolvedDefaultValue = hasDefault ? '$defaultValue' : '';
@@ -198,6 +201,9 @@ class Logger {
   }
 
   /// Prompts user for a free-form list of responses.
+  ///
+  /// This method requires a terminal to be attached to stdout.
+  /// See https://api.dart.dev/stable/dart-io/Stdout/hasTerminal.html.
   List<String> promptAny(String? message, {String separator = ','}) {
     _stdin
       ..echoMode = false
@@ -258,6 +264,9 @@ class Logger {
   }
 
   /// Prompts user with a yes/no question.
+  ///
+  /// This method requires a terminal to be attached to stdout.
+  /// See https://api.dart.dev/stable/dart-io/Stdout/hasTerminal.html.
   bool confirm(String? message, {bool defaultValue = false}) {
     final suffix = ' ${darkGray.wrap('(${defaultValue.toYesNo()})')}';
     final resolvedMessage = '$message$suffix ';
@@ -287,6 +296,9 @@ class Logger {
   ///
   /// An optional [defaultValue] can be specified.
   /// The [defaultValue] must be one of the provided [choices].
+  ///
+  /// This method requires a terminal to be attached to stdout.
+  /// See https://api.dart.dev/stable/dart-io/Stdout/hasTerminal.html.
   T chooseOne<T extends Object?>(
     String? message, {
     required List<T> choices,
@@ -380,6 +392,9 @@ class Logger {
   ///
   /// An optional list of [defaultValues] can be specified.
   /// The [defaultValues] must be one of the provided [choices].
+  ///
+  /// This method requires a terminal to be attached to stdout.
+  /// See https://api.dart.dev/stable/dart-io/Stdout/hasTerminal.html.
   List<T> chooseAny<T extends Object?>(
     String? message, {
     required List<T> choices,

--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -512,10 +512,20 @@ class Logger {
   }
 
   void _ensureTerminalAttached() {
-    if (!_stdout.hasTerminal) {
-      throw StateError('No terminal attached to stdout.');
-    }
+    if (!_stdout.hasTerminal) throw NoTerminalAttachedError();
   }
+}
+
+/// {@template no_terminal_attached_error}
+/// A [StateError] thrown when input is requested in
+/// an environment where no terminal is attached.
+/// {@endtemplate}
+class NoTerminalAttachedError extends StateError {
+  /// {@macro no_terminal_attached_error}
+  NoTerminalAttachedError() : super('''
+No terminal attached to stdout.
+Ensure a terminal is attached via "stdout.hasTerminal" before requesting input.
+''');
 }
 
 extension on bool {

--- a/packages/mason_logger/test/src/mason_logger_test.dart
+++ b/packages/mason_logger/test/src/mason_logger_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mason_logger/src/io.dart';
+import 'package:mason_logger/src/mason_logger.dart';
 import 'package:mason_logger/src/terminal_overrides.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
@@ -342,7 +343,7 @@ void main() {
     });
 
     group('.prompt', () {
-      test('throws StateError when no terminal is attached', () {
+      test('throws NoTerminalAttachedError when no terminal is attached', () {
         when(() => stdout.hasTerminal).thenReturn(false);
         IOOverrides.runZoned(
           () {
@@ -350,13 +351,7 @@ void main() {
             const prompt = '$message ';
             expect(
               () => Logger().prompt(message),
-              throwsA(
-                isA<StateError>().having(
-                  (e) => e.message,
-                  'message',
-                  'No terminal attached to stdout.',
-                ),
-              ),
+              throwsA(isA<NoTerminalAttachedError>()),
             );
             verify(() => stdout.write(prompt)).called(1);
           },
@@ -472,7 +467,7 @@ void main() {
     });
 
     group('.confirm', () {
-      test('throws StateError when no terminal is attached', () {
+      test('throws NoTerminalAttachedError when no terminal is attached', () {
         when(() => stdout.hasTerminal).thenReturn(false);
         IOOverrides.runZoned(
           () {
@@ -480,13 +475,7 @@ void main() {
             final prompt = 'test message ${darkGray.wrap('(y/N)')} ';
             expect(
               () => Logger().confirm(message),
-              throwsA(
-                isA<StateError>().having(
-                  (e) => e.message,
-                  'message',
-                  'No terminal attached to stdout.',
-                ),
-              ),
+              throwsA(isA<NoTerminalAttachedError>()),
             );
             verify(() => stdout.write(prompt)).called(1);
           },
@@ -665,7 +654,7 @@ void main() {
     });
 
     group('.chooseAny', () {
-      test('throws StateError when no terminal is attached', () {
+      test('throws NoTerminalAttachedError when no terminal is attached', () {
         when(() => stdout.hasTerminal).thenReturn(false);
         IOOverrides.runZoned(
           () {
@@ -674,13 +663,7 @@ void main() {
                 'test message',
                 choices: ['a', 'b', 'c'],
               ),
-              throwsA(
-                isA<StateError>().having(
-                  (e) => e.message,
-                  'message',
-                  'No terminal attached to stdout.',
-                ),
-              ),
+              throwsA(isA<NoTerminalAttachedError>()),
             );
           },
           stdout: () => stdout,
@@ -1168,7 +1151,7 @@ void main() {
     });
 
     group('.chooseOne', () {
-      test('throws StateError when no terminal is attached', () {
+      test('throws NoTerminalAttachedError when no terminal is attached', () {
         when(() => stdout.hasTerminal).thenReturn(false);
         IOOverrides.runZoned(
           () {
@@ -1177,13 +1160,7 @@ void main() {
                 'test message',
                 choices: ['a', 'b', 'c'],
               ),
-              throwsA(
-                isA<StateError>().having(
-                  (e) => e.message,
-                  'message',
-                  'No terminal attached to stdout.',
-                ),
-              ),
+              throwsA(isA<NoTerminalAttachedError>()),
             );
           },
           stdout: () => stdout,
@@ -1627,20 +1604,14 @@ void main() {
     });
 
     group('promptAny', () {
-      test('throws StateError when no terminal is attached', () {
+      test('throws NoTerminalAttachedError when no terminal is attached', () {
         when(() => stdout.hasTerminal).thenReturn(false);
         IOOverrides.runZoned(
           () {
             const message = 'test message';
             expect(
               () => Logger().promptAny(message),
-              throwsA(
-                isA<StateError>().having(
-                  (e) => e.message,
-                  'message',
-                  'No terminal attached to stdout.',
-                ),
-              ),
+              throwsA(isA<NoTerminalAttachedError>()),
             );
             verify(() => stdout.write('$message ')).called(1);
           },

--- a/packages/mason_logger/test/src/mason_logger_test.dart
+++ b/packages/mason_logger/test/src/mason_logger_test.dart
@@ -22,6 +22,7 @@ void main() {
       stderr = _MockStdout();
 
       when(() => stdout.supportsAnsiEscapes).thenReturn(true);
+      when(() => stdout.hasTerminal).thenReturn(true);
     });
 
     group('theme', () {
@@ -341,6 +342,29 @@ void main() {
     });
 
     group('.prompt', () {
+      test('throws StateError when no terminal is attached', () {
+        when(() => stdout.hasTerminal).thenReturn(false);
+        IOOverrides.runZoned(
+          () {
+            const message = 'test message';
+            const prompt = '$message ';
+            expect(
+              () => Logger().prompt(message),
+              throwsA(
+                isA<StateError>().having(
+                  (e) => e.message,
+                  'message',
+                  'No terminal attached to stdout.',
+                ),
+              ),
+            );
+            verify(() => stdout.write(prompt)).called(1);
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
+
       test('writes line to stdout and reads line from stdin', () {
         IOOverrides.runZoned(
           () {
@@ -448,6 +472,29 @@ void main() {
     });
 
     group('.confirm', () {
+      test('throws StateError when no terminal is attached', () {
+        when(() => stdout.hasTerminal).thenReturn(false);
+        IOOverrides.runZoned(
+          () {
+            const message = 'test message';
+            final prompt = 'test message ${darkGray.wrap('(y/N)')} ';
+            expect(
+              () => Logger().confirm(message),
+              throwsA(
+                isA<StateError>().having(
+                  (e) => e.message,
+                  'message',
+                  'No terminal attached to stdout.',
+                ),
+              ),
+            );
+            verify(() => stdout.write(prompt)).called(1);
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
+
       test('writes line to stdout and reads line from stdin (default no)', () {
         IOOverrides.runZoned(
           () {
@@ -618,6 +665,29 @@ void main() {
     });
 
     group('.chooseAny', () {
+      test('throws StateError when no terminal is attached', () {
+        when(() => stdout.hasTerminal).thenReturn(false);
+        IOOverrides.runZoned(
+          () {
+            expect(
+              () => Logger().chooseAny(
+                'test message',
+                choices: ['a', 'b', 'c'],
+              ),
+              throwsA(
+                isA<StateError>().having(
+                  (e) => e.message,
+                  'message',
+                  'No terminal attached to stdout.',
+                ),
+              ),
+            );
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
+
       test('exits when control+c is pressed', () {
         final exitCalls = <int>[];
         try {
@@ -1098,6 +1168,29 @@ void main() {
     });
 
     group('.chooseOne', () {
+      test('throws StateError when no terminal is attached', () {
+        when(() => stdout.hasTerminal).thenReturn(false);
+        IOOverrides.runZoned(
+          () {
+            expect(
+              () => Logger().chooseOne(
+                'test message',
+                choices: ['a', 'b', 'c'],
+              ),
+              throwsA(
+                isA<StateError>().having(
+                  (e) => e.message,
+                  'message',
+                  'No terminal attached to stdout.',
+                ),
+              ),
+            );
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
+
       test('exits when control+c is pressed', () {
         final exitCalls = <int>[];
         try {
@@ -1534,6 +1627,28 @@ void main() {
     });
 
     group('promptAny', () {
+      test('throws StateError when no terminal is attached', () {
+        when(() => stdout.hasTerminal).thenReturn(false);
+        IOOverrides.runZoned(
+          () {
+            const message = 'test message';
+            expect(
+              () => Logger().promptAny(message),
+              throwsA(
+                isA<StateError>().having(
+                  (e) => e.message,
+                  'message',
+                  'No terminal attached to stdout.',
+                ),
+              ),
+            );
+            verify(() => stdout.write('$message ')).called(1);
+          },
+          stdout: () => stdout,
+          stdin: () => stdin,
+        );
+      });
+
       test('returns empty list', () {
         final keyStrokes = [KeyStroke.control(ControlCharacter.ctrlJ)];
         TerminalOverrides.runZoned(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

<!--- Describe your changes in detail -->
- fix(mason_logger): throw `StateError` when prompting with no terminal attached
  - Currently if mason_logger is used to prompt for input from a user in an environment with no terminal attached (e.g. CI), the process will hang indefinitely. This change adjusts the behavior to throw a `StateError` in order to make it clear that prompting for input should only be done in contexts where a terminal is attached.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
