### PR TITLE
feat(mason_logger): add `interval` to `ProgressAnimation`

### DIFF
--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -24,7 +24,12 @@ class ProgressOptions {
 /// {@endtemplate}
 class ProgressAnimation {
   /// {@macro progress_animation}
-  const ProgressAnimation({this.frames = _defaultFrames, this.duration});
+  const ProgressAnimation({
+    this.frames = _defaultFrames,
+    this.interval = _defaultInterval,
+  });
+
+  static const _defaultInterval = Duration(milliseconds: 80);
 
   static const _defaultFrames = [
     '⠋',
@@ -42,8 +47,10 @@ class ProgressAnimation {
   /// The list of animation frames.
   final List<String> frames;
 
-  /// The duration between frame changes.
-  final Duration? duration;
+  /// The interval at which new frames are produced.
+  /// In other words, the amount of time spent showing a single frame.
+  /// Defaults to 80ms per frame.
+  final Duration interval;
 }
 
 /// {@template progress}
@@ -72,10 +79,7 @@ class Progress {
       return;
     }
 
-    _timer = Timer.periodic(
-      options.animation.duration ?? const Duration(milliseconds: 80),
-      _onTick,
-    );
+    _timer = Timer.periodic(options.animation.interval, _onTick);
   }
 
   static const _padding = 15;

--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -24,7 +24,7 @@ class ProgressOptions {
 /// {@endtemplate}
 class ProgressAnimation {
   /// {@macro progress_animation}
-  const ProgressAnimation({this.frames = _defaultFrames});
+  const ProgressAnimation({this.frames = _defaultFrames, this.duration});
 
   static const _defaultFrames = [
     '⠋',
@@ -41,6 +41,9 @@ class ProgressAnimation {
 
   /// The list of animation frames.
   final List<String> frames;
+
+  /// The duration between frame changes.
+  final Duration? duration;
 }
 
 /// {@template progress}
@@ -69,7 +72,10 @@ class Progress {
       return;
     }
 
-    _timer = Timer.periodic(const Duration(milliseconds: 80), _onTick);
+    _timer = Timer.periodic(
+      options.animation.duration ?? const Duration(milliseconds: 80),
+      _onTick,
+    );
   }
 
   static const _padding = 15;

--- a/packages/mason_logger/test/src/progress_test.dart
+++ b/packages/mason_logger/test/src/progress_test.dart
@@ -167,7 +167,7 @@ void main() {
           verifyInOrder([
             () {
               stdout.write(
-                '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}⠋')} $message... ${darkGray.wrap('(0.1s)')}''',
+                '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}+')} $message... ${darkGray.wrap('(0.1s)')}''',
               );
             },
             () {

--- a/packages/mason_logger/test/src/progress_test.dart
+++ b/packages/mason_logger/test/src/progress_test.dart
@@ -167,7 +167,7 @@ void main() {
           verifyInOrder([
             () {
               stdout.write(
-                '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}+')} $message... ${darkGray.wrap('(0.1s)')}''',
+                '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}⠋')} $message... ${darkGray.wrap('(0.1s)')}''',
               );
             },
             () {
@@ -186,6 +186,37 @@ void main() {
               );
             },
           ]);
+        },
+        stdout: () => stdout,
+        stdin: () => stdin,
+      );
+    });
+
+    test('writes custom progress interval to stdout', () async {
+      await _runZoned(
+        () async {
+          const time = '(0.Xs)';
+          const message = 'test message';
+          const progressOptions = ProgressOptions(
+            animation: ProgressAnimation(interval: Duration(milliseconds: 400)),
+          );
+          final done = Logger().progress(message, options: progressOptions);
+          await Future<void>.delayed(const Duration(milliseconds: 400));
+          done.complete();
+          verifyInOrder([
+            () {
+              stdout.write(
+                '''${lightGreen.wrap('\b${'\b' * (message.length + 4 + time.length)}⠋')} $message... ${darkGray.wrap('(0.1s)')}''',
+              );
+            },
+            () {
+              stdout.write(
+                '''\b${'\b' * (message.length + 4 + time.length)}\u001b[2K${lightGreen.wrap('✓')} $message ${darkGray.wrap('(0.4s)')}\n''',
+              );
+            },
+          ]);
+          verifyNever(() => stdout.write(any(that: contains('0.2s'))));
+          verifyNever(() => stdout.write(any(that: contains('0.3s'))));
         },
         stdout: () => stdout,
         stdin: () => stdin,


### PR DESCRIPTION
Add Duration parameter to logger.progress() for customizable frame change speed

## Status

Ready

## Description

Added new parameter to the **ProgressAnimation** class to **control the speed of changing
between frames** because for me the default was so fast (80ms) 

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
