### PR TITLE
Fix logger choices rendering at the end of the terminal

### DIFF
--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -340,7 +340,7 @@ class Logger {
     _stdin
       ..echoMode = false
       ..lineMode = false;
-
+    _reserveLines(choices.length + 1);
     writeChoices();
 
     T? result;
@@ -440,7 +440,7 @@ class Logger {
     _stdin
       ..echoMode = false
       ..lineMode = false;
-
+    _reserveLines(choices.length + 1);
     writeChoices();
 
     List<T>? results;
@@ -492,6 +492,15 @@ class Logger {
     }
 
     return results;
+  }
+
+  void _reserveLines(int count) {
+    if (!_stdout.hasTerminal || count <= 0) {
+      return;
+    }
+    _stdout
+      ..write('\n' * count)
+      ..write('\x1b[${count}A');
   }
 
   String? _readLineSync() {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

<!--- Describe your changes in detail -->

Write `choices.length + 1` empty lines before actually writing choices to fix cursor save/restore at the end of the terminal.
This implementation doesn't work properly when the message or any of the choices render as multiple lines, but with single lines it seems to fix #507 and #1356.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore