### PR TITLE
chore(mason_logger): bump win32 to v6

### DIFF
--- a/packages/mason_logger/lib/src/ffi/unix_terminal.dart
+++ b/packages/mason_logger/lib/src/ffi/unix_terminal.dart
@@ -114,20 +114,16 @@ final class TermIOS extends Struct {
 }
 
 // int tcgetattr(int, struct termios *);
-typedef TCGetAttrNative = Int32 Function(
-  Int32 fildes,
-  Pointer<TermIOS> termios,
-);
+typedef TCGetAttrNative =
+    Int32 Function(Int32 fildes, Pointer<TermIOS> termios);
 typedef TCGetAttrDart = int Function(int fildes, Pointer<TermIOS> termios);
 
 // int tcsetattr(int, int, const struct termios *);
-typedef TCSetAttrNative = Int32 Function(
-  Int32 fildes,
-  Int32 optional_actions,
-  Pointer<TermIOS> termios,
-);
-typedef TCSetAttrDart = int Function(
-  int fildes,
-  int optional_actions,
-  Pointer<TermIOS> termios,
-);
+typedef TCSetAttrNative =
+    Int32 Function(
+      Int32 fildes,
+      Int32 optional_actions,
+      Pointer<TermIOS> termios,
+    );
+typedef TCSetAttrDart =
+    int Function(int fildes, int optional_actions, Pointer<TermIOS> termios);

--- a/packages/mason_logger/lib/src/ffi/windows_terminal.dart
+++ b/packages/mason_logger/lib/src/ffi/windows_terminal.dart
@@ -5,17 +5,15 @@ import 'package:mason_logger/src/ffi/terminal.dart';
 import 'package:win32/win32.dart';
 
 class WindowsTerminal implements Terminal {
-  WindowsTerminal() {
-    outputHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-    inputHandle = GetStdHandle(STD_INPUT_HANDLE);
-  }
+  WindowsTerminal() : inputHandle = GetStdHandle(STD_INPUT_HANDLE).value;
 
-  late final int inputHandle;
-  late final int outputHandle;
+  final HANDLE inputHandle;
 
   @override
   void enableRawMode() {
-    const dwMode = (~ENABLE_ECHO_INPUT) &
+    final dwMode =
+        const CONSOLE_MODE(-1) &
+        (~ENABLE_ECHO_INPUT) &
         (~ENABLE_PROCESSED_INPUT) &
         (~ENABLE_LINE_INPUT) &
         (~ENABLE_WINDOW_INPUT);
@@ -24,7 +22,8 @@ class WindowsTerminal implements Terminal {
 
   @override
   void disableRawMode() {
-    const dwMode = ENABLE_ECHO_INPUT |
+    final dwMode =
+        ENABLE_ECHO_INPUT |
         ENABLE_EXTENDED_FLAGS |
         ENABLE_INSERT_MODE |
         ENABLE_LINE_INPUT |

--- a/packages/mason_logger/lib/src/io.dart
+++ b/packages/mason_logger/lib/src/io.dart
@@ -145,7 +145,7 @@ enum ControlCharacter {
   F4,
 
   /// Unknown control character
-  unknown
+  unknown,
 }
 
 /// {@template key_stroke}
@@ -161,10 +161,7 @@ class KeyStroke {
   /// {@macro key_stroke}
   factory KeyStroke.char(String char) {
     assert(char.length == 1, 'characters must be a single unit');
-    return KeyStroke(
-      char: char,
-      controlChar: ControlCharacter.none,
-    );
+    return KeyStroke(char: char, controlChar: ControlCharacter.none);
   }
 
   /// {@macro key_stroke}
@@ -233,43 +230,25 @@ KeyStroke readKey() {
 
             escapeSequence.add(String.fromCharCode(charCode));
             if (escapeSequence[2] != '~') {
-              keyStroke = KeyStroke.control(
-                ControlCharacter.unknown,
-              );
+              keyStroke = KeyStroke.control(ControlCharacter.unknown);
             } else {
               switch (escapeSequence[1]) {
                 case '1':
-                  keyStroke = KeyStroke.control(
-                    ControlCharacter.home,
-                  );
+                  keyStroke = KeyStroke.control(ControlCharacter.home);
                 case '3':
-                  keyStroke = KeyStroke.control(
-                    ControlCharacter.delete,
-                  );
+                  keyStroke = KeyStroke.control(ControlCharacter.delete);
                 case '4':
-                  keyStroke = KeyStroke.control(
-                    ControlCharacter.end,
-                  );
+                  keyStroke = KeyStroke.control(ControlCharacter.end);
                 case '5':
-                  keyStroke = KeyStroke.control(
-                    ControlCharacter.pageUp,
-                  );
+                  keyStroke = KeyStroke.control(ControlCharacter.pageUp);
                 case '6':
-                  keyStroke = KeyStroke.control(
-                    ControlCharacter.pageDown,
-                  );
+                  keyStroke = KeyStroke.control(ControlCharacter.pageDown);
                 case '7':
-                  keyStroke = KeyStroke.control(
-                    ControlCharacter.home,
-                  );
+                  keyStroke = KeyStroke.control(ControlCharacter.home);
                 case '8':
-                  keyStroke = KeyStroke.control(
-                    ControlCharacter.end,
-                  );
+                  keyStroke = KeyStroke.control(ControlCharacter.end);
                 default:
-                  keyStroke = KeyStroke.control(
-                    ControlCharacter.unknown,
-                  );
+                  keyStroke = KeyStroke.control(ControlCharacter.unknown);
               }
             }
           } else {

--- a/packages/mason_logger/lib/src/mason_logger.dart
+++ b/packages/mason_logger/lib/src/mason_logger.dart
@@ -40,12 +40,12 @@ class LogTheme {
     LogStyle? warn,
     LogStyle? alert,
     LogStyle? success,
-  })  : detail = detail ?? _detailStyle,
-        info = info ?? _infoStyle,
-        err = err ?? _errStyle,
-        warn = warn ?? _warnStyle,
-        alert = alert ?? _alertStyle,
-        success = success ?? _successStyle;
+  }) : detail = detail ?? _detailStyle,
+       info = info ?? _infoStyle,
+       err = err ?? _errStyle,
+       warn = warn ?? _warnStyle,
+       alert = alert ?? _alertStyle,
+       success = success ?? _successStyle;
 
   /// The [LogStyle] used by [detail].
   final LogStyle detail;
@@ -185,16 +185,19 @@ class Logger {
   String prompt(String? message, {Object? defaultValue, bool hidden = false}) {
     final hasDefault = defaultValue != null && '$defaultValue'.isNotEmpty;
     final resolvedDefaultValue = hasDefault ? '$defaultValue' : '';
-    final suffix =
-        hasDefault ? ' ${darkGray.wrap('($resolvedDefaultValue)')}' : '';
+    final suffix = hasDefault
+        ? ' ${darkGray.wrap('($resolvedDefaultValue)')}'
+        : '';
     final resolvedMessage = '$message$suffix ';
     _stdout.write(resolvedMessage);
     final input = hidden ? _readLineHiddenSync() : _readLineSync();
-    final response =
-        input == null || input.isEmpty ? resolvedDefaultValue : input;
+    final response = input == null || input.isEmpty
+        ? resolvedDefaultValue
+        : input;
     final lines = resolvedMessage.split('\n').length - 1;
-    final prefix =
-        lines > 1 ? '\x1b[A\u001B[2K\u001B[${lines}A' : '\x1b[A\u001B[2K';
+    final prefix = lines > 1
+        ? '\x1b[A\u001B[2K\u001B[${lines}A'
+        : '\x1b[A\u001B[2K';
     _stdout.writeln(
       '''$prefix$resolvedMessage${styleDim.wrap(lightCyan.wrap(hidden ? '******' : response))}''',
     );
@@ -217,12 +220,13 @@ class Logger {
 
     while (true) {
       final key = _readKey();
-      final isEnterOrReturnKey = key.controlChar == ControlCharacter.ctrlJ ||
+      final isEnterOrReturnKey =
+          key.controlChar == ControlCharacter.ctrlJ ||
           key.controlChar == ControlCharacter.ctrlM;
       final isDeleteOrBackspaceKey =
           key.controlChar == ControlCharacter.delete ||
-              key.controlChar == ControlCharacter.backspace ||
-              key.controlChar == ControlCharacter.ctrlH;
+          key.controlChar == ControlCharacter.backspace ||
+          key.controlChar == ControlCharacter.ctrlH;
 
       if (isEnterOrReturnKey) break;
 
@@ -284,8 +288,9 @@ class Logger {
         ? defaultValue
         : input.toBoolean() ?? defaultValue;
     final lines = resolvedMessage.split('\n').length - 1;
-    final prefix =
-        lines > 1 ? '\x1b[A\u001B[2K\u001B[${lines}A' : '\x1b[A\u001B[2K';
+    final prefix = lines > 1
+        ? '\x1b[A\u001B[2K\u001B[${lines}A'
+        : '\x1b[A\u001B[2K';
     _stdout.writeln(
       '''$prefix$resolvedMessage${styleDim.wrap(lightCyan.wrap(response ? 'Yes' : 'No'))}''',
     );
@@ -352,8 +357,8 @@ class Logger {
           key.controlChar == ControlCharacter.arrowDown || key.char == 'j';
       final isReturnOrEnterOrSpaceKey =
           key.controlChar == ControlCharacter.ctrlJ ||
-              key.controlChar == ControlCharacter.ctrlM ||
-              key.char == ' ';
+          key.controlChar == ControlCharacter.ctrlM ||
+          key.char == ' ';
 
       if (isArrowUpOrKKey) {
         index = (index - 1) % (choices.length);
@@ -451,7 +456,8 @@ class Logger {
       final keyIsDownOrJKey =
           key.controlChar == ControlCharacter.arrowDown || key.char == 'j';
       final keyIsSpaceKey = key.char == ' ';
-      final keyIsEnterOrReturnKey = key.controlChar == ControlCharacter.ctrlJ ||
+      final keyIsEnterOrReturnKey =
+          key.controlChar == ControlCharacter.ctrlJ ||
           key.controlChar == ControlCharacter.ctrlM;
 
       if (keyIsUpOrKKey) {
@@ -538,7 +544,8 @@ class Logger {
 /// {@endtemplate}
 class NoTerminalAttachedError extends StateError {
   /// {@macro no_terminal_attached_error}
-  NoTerminalAttachedError() : super('''
+  NoTerminalAttachedError()
+    : super('''
 No terminal attached to stdout.
 Ensure a terminal is attached via "stdout.hasTerminal" before requesting input.
 ''');

--- a/packages/mason_logger/lib/src/progress.dart
+++ b/packages/mason_logger/lib/src/progress.dart
@@ -63,8 +63,8 @@ class Progress {
     this._stdout,
     this._level, {
     ProgressOptions options = const ProgressOptions(),
-  })  : _stopwatch = Stopwatch(),
-        _options = options {
+  }) : _stopwatch = Stopwatch(),
+       _options = options {
     _stopwatch
       ..reset()
       ..start();
@@ -188,8 +188,9 @@ class Progress {
     final elapsedTime = _stopwatch.elapsed.inMilliseconds;
     final displayInMilliseconds = elapsedTime < 100;
     final time = displayInMilliseconds ? elapsedTime : elapsedTime / 1000;
-    final formattedTime =
-        displayInMilliseconds ? '${time}ms' : '${time.toStringAsFixed(1)}s';
+    final formattedTime = displayInMilliseconds
+        ? '${time}ms'
+        : '${time.toStringAsFixed(1)}s';
     return '${darkGray.wrap('($formattedTime)')}';
   }
 }

--- a/packages/mason_logger/pubspec.yaml
+++ b/packages/mason_logger/pubspec.yaml
@@ -16,12 +16,12 @@ platforms:
   windows:
 
 environment:
-  sdk: ">=3.5.0 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   ffi: ^2.1.3
   io: ^1.0.4
-  win32: ^5.11.0
+  win32: ^6.3.0
 
 dev_dependencies:
   meta: ^1.15.0


### PR DESCRIPTION
## Status

**READY**

## Description

Bump `mason_logger` to `win32: ^6.3.0`; raise its Dart SDK floor to `>=3.10.0 <4.0.0`; migrate terminal handles and console modes for win32 6 type-safe APIs.

Local verification: format, analyze, 134 tests with LCOV, and macOS E2E fixture pass.

## Type Change

- [ ] ✨ New feature (non-breaking change adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change fixes issue)
- [x] ❌ Breaking change (fix or feature would cause existing functionality change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [x] 🗑️ Chore